### PR TITLE
[uikit-library]: add missing component variations from UIkit docs review

### DIFF
--- a/ui-frameworks/ui-kit-framework/pom.xml
+++ b/ui-frameworks/ui-kit-framework/pom.xml
@@ -15,7 +15,7 @@
 
     <version>0.0.1</version>
 
-    <name>Tachyons Framework</name>
+    <name>UIkit Framework</name>
 
     <packaging>bundle</packaging>
 

--- a/vendor-libraries/ui-kit/src/content/jcr_root/apps/kestros/commons/components/content/heading/ui-kit-lib/3.23.6/variations/font-size/.content.xml
+++ b/vendor-libraries/ui-kit/src/content/jcr_root/apps/kestros/commons/components/content/heading/ui-kit-lib/3.23.6/variations/font-size/.content.xml
@@ -23,5 +23,14 @@
     <uk-heading-3xlarge jcr:primaryType="kes:ComponentVariation"
                           jcr:title="XXX-Large"
                           inline="true"/>
+    <uk-text-small jcr:primaryType="kes:ComponentVariation"
+                   jcr:title="Text - Extra Small"
+                   inline="true"/>
+    <uk-text-default jcr:primaryType="kes:ComponentVariation"
+                     jcr:title="Text - Default"
+                     inline="true"/>
+    <uk-text-large jcr:primaryType="kes:ComponentVariation"
+                   jcr:title="Text - Large"
+                   inline="true"/>
 
 </jcr:root>

--- a/vendor-libraries/ui-kit/src/content/jcr_root/apps/kestros/commons/components/content/heading/ui-kit-lib/3.23.6/variations/font-weight/.content.xml
+++ b/vendor-libraries/ui-kit/src/content/jcr_root/apps/kestros/commons/components/content/heading/ui-kit-lib/3.23.6/variations/font-weight/.content.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:kes="http://kestros.io/kes/1.0"
+          jcr:primaryType="kes:ComponentVariationGroup"
+          jcr:title="Font Weight"
+          jcr:description=""
+          mutuallyExclusive="true">
+    <uk-text-light jcr:primaryType="kes:ComponentVariation"
+                   jcr:title="Light"
+                   inline="true"/>
+    <uk-text-normal jcr:primaryType="kes:ComponentVariation"
+                    jcr:title="Normal"
+                    inline="true"/>
+    <uk-text-bold jcr:primaryType="kes:ComponentVariation"
+                  jcr:title="Bold"
+                  inline="true"/>
+</jcr:root>

--- a/vendor-libraries/ui-kit/src/content/jcr_root/apps/kestros/commons/components/content/heading/ui-kit-lib/3.23.6/variations/modifiers/.content.xml
+++ b/vendor-libraries/ui-kit/src/content/jcr_root/apps/kestros/commons/components/content/heading/ui-kit-lib/3.23.6/variations/modifiers/.content.xml
@@ -11,4 +11,7 @@
     <uk-heading-bullet jcr:primaryType="kes:ComponentVariation"
                       jcr:title="Bullet"
                       inline="true"/>
+    <uk-card-title jcr:primaryType="kes:ComponentVariation"
+                   jcr:title="Card Title"
+                   inline="true"/>
 </jcr:root>

--- a/vendor-libraries/ui-kit/src/content/jcr_root/apps/kestros/commons/components/content/heading/ui-kit-lib/3.23.6/variations/text-color/.content.xml
+++ b/vendor-libraries/ui-kit/src/content/jcr_root/apps/kestros/commons/components/content/heading/ui-kit-lib/3.23.6/variations/text-color/.content.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:kes="http://kestros.io/kes/1.0"
+          jcr:primaryType="kes:ComponentVariationGroup"
+          jcr:title="Text Color"
+          jcr:description=""
+          mutuallyExclusive="true">
+    <uk-text-muted jcr:primaryType="kes:ComponentVariation"
+                   jcr:title="Muted"
+                   inline="true"/>
+    <uk-text-emphasis jcr:primaryType="kes:ComponentVariation"
+                      jcr:title="Emphasis"
+                      inline="true"/>
+    <uk-text-primary jcr:primaryType="kes:ComponentVariation"
+                     jcr:title="Primary"
+                     inline="true"/>
+    <uk-text-secondary jcr:primaryType="kes:ComponentVariation"
+                       jcr:title="Secondary"
+                       inline="true"/>
+    <uk-text-success jcr:primaryType="kes:ComponentVariation"
+                     jcr:title="Success"
+                     inline="true"/>
+    <uk-text-warning jcr:primaryType="kes:ComponentVariation"
+                     jcr:title="Warning"
+                     inline="true"/>
+    <uk-text-danger jcr:primaryType="kes:ComponentVariation"
+                    jcr:title="Danger"
+                    inline="true"/>
+</jcr:root>

--- a/vendor-libraries/ui-kit/src/content/jcr_root/apps/kestros/commons/components/content/heading/ui-kit-lib/3.23.6/variations/text-transform/.content.xml
+++ b/vendor-libraries/ui-kit/src/content/jcr_root/apps/kestros/commons/components/content/heading/ui-kit-lib/3.23.6/variations/text-transform/.content.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:kes="http://kestros.io/kes/1.0"
+          jcr:primaryType="kes:ComponentVariationGroup"
+          jcr:title="Text Transform"
+          jcr:description=""
+          mutuallyExclusive="true">
+    <uk-text-uppercase jcr:primaryType="kes:ComponentVariation"
+                       jcr:title="Uppercase"
+                       inline="true"/>
+    <uk-text-capitalize jcr:primaryType="kes:ComponentVariation"
+                        jcr:title="Capitalize"
+                        inline="true"/>
+    <uk-text-lowercase jcr:primaryType="kes:ComponentVariation"
+                       jcr:title="Lowercase"
+                       inline="true"/>
+</jcr:root>

--- a/vendor-libraries/ui-kit/src/content/jcr_root/apps/kestros/commons/components/content/text/ui-kit-lib/3.23.6/variations/font-weight/.content.xml
+++ b/vendor-libraries/ui-kit/src/content/jcr_root/apps/kestros/commons/components/content/text/ui-kit-lib/3.23.6/variations/font-weight/.content.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:kes="http://kestros.io/kes/1.0"
+          jcr:primaryType="kes:ComponentVariationGroup"
+          jcr:title="Font Weight"
+          jcr:description=""
+          mutuallyExclusive="true">
+    <uk-text-light jcr:primaryType="kes:ComponentVariation"
+                   jcr:title="Light"
+                   inline="true"/>
+    <uk-text-normal jcr:primaryType="kes:ComponentVariation"
+                    jcr:title="Normal"
+                    inline="true"/>
+    <uk-text-bold jcr:primaryType="kes:ComponentVariation"
+                  jcr:title="Bold"
+                  inline="true"/>
+</jcr:root>

--- a/vendor-libraries/ui-kit/src/content/jcr_root/apps/kestros/commons/components/content/text/ui-kit-lib/3.23.6/variations/text-alignment/.content.xml
+++ b/vendor-libraries/ui-kit/src/content/jcr_root/apps/kestros/commons/components/content/text/ui-kit-lib/3.23.6/variations/text-alignment/.content.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:kes="http://kestros.io/kes/1.0"
+          jcr:primaryType="kes:ComponentVariationGroup"
+          jcr:title="Text Alignment"
+          jcr:description=""
+          mutuallyExclusive="true">
+    <uk-text-left jcr:primaryType="kes:ComponentVariation"
+                  jcr:title="Left"
+                  inline="true"/>
+    <uk-text-center jcr:primaryType="kes:ComponentVariation"
+                    jcr:title="Center"
+                    inline="true"/>
+    <uk-text-right jcr:primaryType="kes:ComponentVariation"
+                   jcr:title="Right"
+                   inline="true"/>
+    <uk-text-justify jcr:primaryType="kes:ComponentVariation"
+                     jcr:title="Justify"
+                     inline="true"/>
+</jcr:root>

--- a/vendor-libraries/ui-kit/src/content/jcr_root/apps/kestros/commons/components/content/text/ui-kit-lib/3.23.6/variations/text-color/.content.xml
+++ b/vendor-libraries/ui-kit/src/content/jcr_root/apps/kestros/commons/components/content/text/ui-kit-lib/3.23.6/variations/text-color/.content.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:kes="http://kestros.io/kes/1.0"
+          jcr:primaryType="kes:ComponentVariationGroup"
+          jcr:title="Text Color"
+          jcr:description=""
+          mutuallyExclusive="true">
+    <uk-text-muted jcr:primaryType="kes:ComponentVariation"
+                   jcr:title="Muted"
+                   inline="true"/>
+    <uk-text-emphasis jcr:primaryType="kes:ComponentVariation"
+                      jcr:title="Emphasis"
+                      inline="true"/>
+    <uk-text-primary jcr:primaryType="kes:ComponentVariation"
+                     jcr:title="Primary"
+                     inline="true"/>
+    <uk-text-secondary jcr:primaryType="kes:ComponentVariation"
+                       jcr:title="Secondary"
+                       inline="true"/>
+    <uk-text-success jcr:primaryType="kes:ComponentVariation"
+                     jcr:title="Success"
+                     inline="true"/>
+    <uk-text-warning jcr:primaryType="kes:ComponentVariation"
+                     jcr:title="Warning"
+                     inline="true"/>
+    <uk-text-danger jcr:primaryType="kes:ComponentVariation"
+                    jcr:title="Danger"
+                    inline="true"/>
+</jcr:root>

--- a/vendor-libraries/ui-kit/src/content/jcr_root/apps/kestros/commons/components/content/text/ui-kit-lib/3.23.6/variations/text-transform/.content.xml
+++ b/vendor-libraries/ui-kit/src/content/jcr_root/apps/kestros/commons/components/content/text/ui-kit-lib/3.23.6/variations/text-transform/.content.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:kes="http://kestros.io/kes/1.0"
+          jcr:primaryType="kes:ComponentVariationGroup"
+          jcr:title="Text Transform"
+          jcr:description=""
+          mutuallyExclusive="true">
+    <uk-text-uppercase jcr:primaryType="kes:ComponentVariation"
+                       jcr:title="Uppercase"
+                       inline="true"/>
+    <uk-text-capitalize jcr:primaryType="kes:ComponentVariation"
+                        jcr:title="Capitalize"
+                        inline="true"/>
+    <uk-text-lowercase jcr:primaryType="kes:ComponentVariation"
+                       jcr:title="Lowercase"
+                       inline="true"/>
+</jcr:root>

--- a/vendor-libraries/ui-kit/src/content/jcr_root/apps/kestros/commons/components/content/text/ui-kit-lib/3.23.6/variations/text-wrapping/.content.xml
+++ b/vendor-libraries/ui-kit/src/content/jcr_root/apps/kestros/commons/components/content/text/ui-kit-lib/3.23.6/variations/text-wrapping/.content.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:kes="http://kestros.io/kes/1.0"
+          jcr:primaryType="kes:ComponentVariationGroup"
+          jcr:title="Text Wrapping"
+          jcr:description=""
+          mutuallyExclusive="true">
+    <uk-text-truncate jcr:primaryType="kes:ComponentVariation"
+                      jcr:title="Truncate"
+                      inline="true"/>
+    <uk-text-break jcr:primaryType="kes:ComponentVariation"
+                   jcr:title="Break"
+                   inline="true"/>
+    <uk-text-nowrap jcr:primaryType="kes:ComponentVariation"
+                    jcr:title="No Wrap"
+                    inline="true"/>
+</jcr:root>

--- a/vendor-libraries/ui-kit/src/content/jcr_root/apps/kestros/commons/components/structure/container/ui-kit-lib/3.23.6/variations/background/.content.xml
+++ b/vendor-libraries/ui-kit/src/content/jcr_root/apps/kestros/commons/components/structure/container/ui-kit-lib/3.23.6/variations/background/.content.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:kes="http://kestros.io/kes/1.0"
+          jcr:primaryType="kes:ComponentVariationGroup"
+          jcr:title="Background"
+          jcr:description=""
+          mutuallyExclusive="true">
+    <uk-background-default jcr:primaryType="kes:ComponentVariation"
+                           jcr:title="Default"
+                           inline="true"/>
+    <uk-background-muted jcr:primaryType="kes:ComponentVariation"
+                         jcr:title="Muted"
+                         inline="true"/>
+    <uk-background-primary jcr:primaryType="kes:ComponentVariation"
+                           jcr:title="Primary"
+                           inline="true"/>
+    <uk-background-secondary jcr:primaryType="kes:ComponentVariation"
+                             jcr:title="Secondary"
+                             inline="true"/>
+</jcr:root>

--- a/vendor-libraries/ui-kit/src/content/jcr_root/apps/kestros/commons/components/structure/container/ui-kit-lib/3.23.6/variations/size/.content.xml
+++ b/vendor-libraries/ui-kit/src/content/jcr_root/apps/kestros/commons/components/structure/container/ui-kit-lib/3.23.6/variations/size/.content.xml
@@ -15,6 +15,9 @@
                         jcr:title="Large"
                         inline="true"/>
     <uk-container-xlarge jcr:primaryType="kes:ComponentVariation"
-                        jcr:title="Extra Large"
-                        inline="true"/>
+                         jcr:title="Extra Large"
+                         inline="true"/>
+    <uk-container-expand jcr:primaryType="kes:ComponentVariation"
+                         jcr:title="Expand"
+                         inline="true"/>
 </jcr:root>

--- a/vendor-libraries/ui-kit/src/content/jcr_root/apps/kestros/commons/components/structure/container/ui-kit-lib/3.23.6/variations/text/.content.xml
+++ b/vendor-libraries/ui-kit/src/content/jcr_root/apps/kestros/commons/components/structure/container/ui-kit-lib/3.23.6/variations/text/.content.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:kes="http://kestros.io/kes/1.0"
+          jcr:primaryType="kes:ComponentVariationGroup"
+          jcr:title="Text"
+          jcr:description=""
+          mutuallyExclusive="true">
+    <uk-light jcr:primaryType="kes:ComponentVariation"
+              jcr:title="Light"
+              inline="true"/>
+</jcr:root>

--- a/vendor-libraries/ui-kit/src/content/jcr_root/apps/kestros/commons/components/structure/section/ui-kit-lib/3.23.6/variations/modifiers/.content.xml
+++ b/vendor-libraries/ui-kit/src/content/jcr_root/apps/kestros/commons/components/structure/section/ui-kit-lib/3.23.6/variations/modifiers/.content.xml
@@ -6,11 +6,14 @@
           jcr:description=""
           mutuallyExclusive="false">
 
+    <uk-section-overlap jcr:primaryType="kes:ComponentVariation"
+                        jcr:title="Section Overlap"
+                        inline="true"/>
     <uk-preserve-color jcr:primaryType="kes:ComponentVariation"
-                        jcr:title="Preserve Color"
-                        inline="true"/>
+                       jcr:title="Preserve Color"
+                       inline="true"/>
     <uk-padding-remove-vertical jcr:primaryType="kes:ComponentVariation"
-                        jcr:title="Remove Vertical Padding"
-                        inline="true"/>
+                                jcr:title="Remove Vertical Padding"
+                                inline="true"/>
 
 </jcr:root>

--- a/vendor-libraries/ui-kit/src/content/jcr_root/apps/kestros/commons/components/structure/section/ui-kit-lib/3.23.6/variations/style/.content.xml
+++ b/vendor-libraries/ui-kit/src/content/jcr_root/apps/kestros/commons/components/structure/section/ui-kit-lib/3.23.6/variations/style/.content.xml
@@ -5,6 +5,9 @@
           jcr:title="Style"
           jcr:description=""
           mutuallyExclusive="true">
+    <uk-section-default jcr:primaryType="kes:ComponentVariation"
+                   jcr:title="Default"
+                   inline="true"/>
     <uk-section-primary jcr:primaryType="kes:ComponentVariation"
                    jcr:title="Primary"
                    inline="true"/>

--- a/vendor-libraries/ui-kit/src/content/jcr_root/apps/kestros/commons/components/structure/section/ui-kit-lib/3.23.6/variations/text/.content.xml
+++ b/vendor-libraries/ui-kit/src/content/jcr_root/apps/kestros/commons/components/structure/section/ui-kit-lib/3.23.6/variations/text/.content.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:kes="http://kestros.io/kes/1.0"
+          jcr:primaryType="kes:ComponentVariationGroup"
+          jcr:title="Text"
+          jcr:description=""
+          mutuallyExclusive="true">
+    <uk-dark jcr:primaryType="kes:ComponentVariation"
+             jcr:title="Dark"
+             inline="true"/>
+    <uk-light jcr:primaryType="kes:ComponentVariation"
+              jcr:title="Light"
+              inline="true"/>
+</jcr:root>


### PR DESCRIPTION
## Summary

- Reviewed UIkit 3.x documentation and audited all existing component views in `vendor-libraries/ui-kit` against available UIkit CSS classes
- Added 11 new variation groups and updated 5 existing files across text, heading, container, and section components
- Validated all changes against the dev instance state (instance already had some of these from prior direct edits)

## Changes

### Text component (`content/text`)
- Added `text-color` variation group: muted, emphasis, primary, secondary, success, warning, danger
- Added `font-weight` variation group: light, normal, bold
- Added `text-alignment` variation group: left, center, right, justify
- Added `text-transform` variation group: uppercase, capitalize, lowercase
- Added `text-wrapping` variation group: truncate, break, nowrap

### Heading component (`content/heading`)
- Added `text-color` variation group (same as text)
- Added `font-weight` variation group (same as text)
- Added `text-transform` variation group (same as text)
- Updated `font-size` to include uk-text-small, uk-text-default, uk-text-large options
- Updated `modifiers` to include `uk-card-title`

### Container component (`structure/container`)
- Added `background` variation group: default, muted, primary, secondary
- Added `text` variation group: uk-light
- Updated `size` to include `uk-container-expand`

### Section component (`structure/section`)
- Added `text` variation group: uk-dark, uk-light
- Updated `style` to include `uk-section-default`
- Updated `modifiers` to include `uk-section-overlap`

## Verification
- Both `mvn clean install` passes for `vendor-libraries/ui-kit` and `ui-frameworks/ui-kit-framework`
- Deployed to dev instance (http://192.168.86.216:8000) — all new variation nodes confirmed present in JCR
- Builds on top of existing branch `feature/TASK-144-verify-uikit-framework` (PR #19, which fixes the POM name)

## Note
This PR adds the new AC work (UIkit docs review and variation completeness). It should be reviewed alongside PR #19 or merged after #19.