### PR TITLE
fix: correct Tailwind framework vendor library version

### DIFF
--- a/ui-frameworks/tailwind-framework/src/content/jcr_root/etc/ui-frameworks/tailwind-framework/versions/0.0.1/.content.xml
+++ b/ui-frameworks/tailwind-framework/src/content/jcr_root/etc/ui-frameworks/tailwind-framework/versions/0.0.1/.content.xml
@@ -5,5 +5,5 @@
           jcr:title="Tailwind UI Framework 0.0.1"
           jcr:description=""
           kes:uiFrameworkCode="tailwind"
-          kes:vendorLibraries="[tailwind-css/4.1.0]"
+          kes:vendorLibraries="[tailwind-css/3.4.17]"
 />


### PR DESCRIPTION
## Summary
- Fixes vendor library version reference from `tailwind-css/4.1.0` (non-existent) to `tailwind-css/3.4.17` (actual version)
- Framework follows the config-resource-only pattern: just the `/etc/ui-frameworks/tailwind-framework` config referencing the vendor library via `kes:vendorLibraries`
- No component view overrides (no HTL files, no view folders in `apps/` tree)
- Closed PR #27 which violated the config-only pattern by adding 90+ component layout/variation files

## Changes
- `ui-frameworks/tailwind-framework/versions/0.0.1/.content.xml`: updated `kes:vendorLibraries` from `[tailwind-css/4.1.0]` to `[tailwind-css/3.4.17]`

## Test plan
- [ ] Verify `tailwind-css/3.4.17` vendor library exists in the repo
- [ ] Verify no `apps/` component overrides are present
- [ ] Build passes: `mvn clean package` on `ui-frameworks/tailwind-framework`