### PR TITLE
docs: add usage README for kestros-ui-frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# kestros-ui-frameworks
+# Kestros UI Frameworks
+
+Legacy placeholder repository for the Kestros UI frameworks system. Active development has moved to separate API and core modules.
+
+## Purpose
+
+`kestros-ui-frameworks` was the original monolithic UI frameworks module. It has been split into:
+
+- [`kestros-ui-frameworks-api`](https://github.com/kestros/kestros-ui-frameworks-api) -- API interfaces and model contracts
+- [`kestros-ui-frameworks-core`](https://github.com/kestros/kestros-ui-frameworks-core) -- Service implementations
+
+**Current state:** This repository contains no source code. Use the API and core modules instead.
+
+## Installation & Build
+
+Not applicable -- this repository has no buildable artifacts. Use `kestros-ui-frameworks-api` and `kestros-ui-frameworks-core`.
+
+## Configuration
+
+Not applicable -- no active code.
+
+## API / Service Usage
+
+See [`kestros-ui-frameworks-api`](https://github.com/kestros/kestros-ui-frameworks-api) for interfaces and [`kestros-ui-frameworks-core`](https://github.com/kestros/kestros-ui-frameworks-core) for implementations.
+
+## Dependencies
+
+Not applicable -- this is a legacy placeholder repository.


### PR DESCRIPTION
## Summary
- Adds developer-facing usage documentation following the 6-section structure
- Documents purpose, installation, configuration, API/service usage, and dependencies

Part of TASK-188 — README.md usage docs for remaining repos batch 2.