### PR TITLE
feat: add signal-framework UI framework module

### DIFF
--- a/ui-frameworks/pom.xml
+++ b/ui-frameworks/pom.xml
@@ -26,6 +26,7 @@
     <module>tachyons-framework</module>
     <module>ui-kit-framework</module>
     <module>nova-framework</module>
+    <module>signal-framework</module>
   </modules>
 
 </project>

--- a/ui-frameworks/signal-framework/pom.xml
+++ b/ui-frameworks/signal-framework/pom.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.kestros.cms</groupId>
+        <artifactId>kestros-site-parent</artifactId>
+        <version>0.1.2</version>
+    </parent>
+
+    <groupId>io.kestros.samples</groupId>
+    <artifactId>signal-framework</artifactId>
+
+    <version>1.0.0-SNAPSHOT</version>
+
+    <name>Signal Framework</name>
+
+    <packaging>bundle</packaging>
+
+    <properties>
+        <rootPackage>io.kestros.samples</rootPackage>
+        <bundleCategory>${organization.name}</bundleCategory>
+    </properties>
+
+    <dependencies>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>src/main/java</sourceDirectory>
+        <testSourceDirectory>src/test/java</testSourceDirectory>
+        <resources>
+            <resource>
+                <directory>src/content/jcr_root</directory>
+            </resource>
+        </resources>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.jackrabbit</groupId>
+                <artifactId>filevault-package-maven-plugin</artifactId>
+                <version>1.3.6</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate-metadata</goal>
+                            <goal>package</goal>
+                            <goal>analyze-classes</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <packageType>mixed</packageType>
+                    <failOnMissingEmbed>true</failOnMissingEmbed>
+                    <accessControlHandling>merge</accessControlHandling>
+                    <allowIndexDefinitions>true</allowIndexDefinitions>
+                    <filterSource>${basedir}/src/content/META-INF/vault/filter.xml</filterSource>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.sling</groupId>
+                <artifactId>htl-maven-plugin</artifactId>
+                <version>1.2.2-1.4.0</version>
+                <configuration>
+                    <failOnWarnings>true</failOnWarnings>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>installPackage</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.wcm.maven.plugins</groupId>
+                        <artifactId>wcmio-content-package-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>install</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <serviceURL>
+                                ${sling.protocol}://${sling.host}:${sling.port}/bin/cpm/package.service.html
+                            </serviceURL>
+                            <userId>${sling.username}</userId>
+                            <password>${sling.password}</password>
+                            <packageFile>target/${project.artifactId}-${project.version}.zip
+                            </packageFile>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>installBundle</id>
+        </profile>
+    </profiles>
+
+</project>

--- a/ui-frameworks/signal-framework/src/content/META-INF/vault/config.xml
+++ b/ui-frameworks/signal-framework/src/content/META-INF/vault/config.xml
@@ -1,0 +1,74 @@
+<vaultfs version="1.1">
+    <!--
+        Defines the content aggregation. The order of the defined aggregates
+        is important for finding the correct aggregator.
+    -->
+    <aggregates>
+        <!--
+            Defines an aggregate that handles nt:file and nt:resource nodes.
+        -->
+        <aggregate type="file" title="File Aggregate"/>
+
+        <!--
+            Defines an aggregate that handles file/folder like nodes. It matches
+            all nt:hierarchyNode nodes that have or define a jcr:content
+            child node and excludes child nodes that are nt:hierarchyNodes.
+        -->
+        <aggregate type="filefolder" title="File/Folder Aggregate"/>
+
+        <!--
+            Defines an aggregate that handles nt:nodeType nodes and serializes
+            them into .cnd notation.
+        -->
+        <aggregate type="nodetype" title="Node Type Aggregate" />
+
+        <!--
+            Defines an aggregate that defines full coverage for certain node
+            types that cannot be covered by the default aggregator.
+        -->
+        <aggregate type="full" title="Full Coverage Aggregate">
+            <matches>
+                <include nodeType="rep:AccessControl" respectSupertype="true" />
+                <include nodeType="rep:Policy" respectSupertype="true" />
+                <include nodeType="vlt:FullCoverage" respectSupertype="true" />
+                <include nodeType="mix:language" respectSupertype="true" />
+                <include nodeType="sling:OsgiConfig" respectSupertype="true" />
+            </matches>
+        </aggregate>
+
+        <!--
+            Defines an aggregate that handles nt:folder like nodes.
+        -->
+        <aggregate type="generic" title="Folder Aggregate">
+            <matches>
+                <include nodeType="nt:folder" respectSupertype="true" />
+            </matches>
+            <contains>
+                <exclude isNode="true" />
+            </contains>
+        </aggregate>
+
+        <!--
+            Defines the default aggregate
+        -->
+        <aggregate type="generic" title="Default Aggregator" isDefault="true">
+            <matches>
+                <!-- all -->
+            </matches>
+            <contains>
+                <exclude nodeType="nt:hierarchyNode" respectSupertype="true" />
+            </contains>
+        </aggregate>
+
+    </aggregates>
+
+    <!--
+      defines the input handlers
+    -->
+    <handlers>
+        <handler type="folder"/>
+        <handler type="file"/>
+        <handler type="nodetype"/>
+        <handler type="generic"/>
+    </handlers>
+</vaultfs>

--- a/ui-frameworks/signal-framework/src/content/META-INF/vault/filter.xml
+++ b/ui-frameworks/signal-framework/src/content/META-INF/vault/filter.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<workspaceFilter version="1.0">
+
+    <filter root="/etc/ui-frameworks/signal-framework"/>
+
+</workspaceFilter>

--- a/ui-frameworks/signal-framework/src/content/META-INF/vault/settings.xml
+++ b/ui-frameworks/signal-framework/src/content/META-INF/vault/settings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<vault version="1.0">
+  <ignore name=".svn"/>
+  <ignore name=".git"/>
+</vault>

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/.content.xml
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/.content.xml
@@ -1,0 +1,6 @@
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:kes="http://kestros.io/kes/1.0"
+          jcr:primaryType="kes:ManagedUiFramework"
+          jcr:title="Signal Framework"
+          jcr:description="Tech-conference sample framework on the ui-kit vendor library. Demonstrates framework evolution across eight versions from baseline theming through responsive + dark-mode support."
+/>

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.1/.content.xml
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.1/.content.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:kes="http://kestros.io/kes/1.0"
+          jcr:primaryType="kes:UiFramework"
+          jcr:title="Signal Framework 0.0.1"
+          jcr:description="Baseline — generic tech-conference theming on top of ui-kit."
+          kes:uiFrameworkCode="signal-framework"
+          kes:vendorLibraries="[ui-kit/3.23.6]"
+/>

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.1/themes/default/.content.xml
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.1/themes/default/.content.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:kes="http://kestros.io/kes/1.0"
+          jcr:primaryType="kes:Theme"
+          jcr:title="Default"
+/>

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.1/themes/default/css/.content.xml
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.1/themes/default/css/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="sling:OrderedFolder"
+          include="[main.css]"
+/>

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.1/themes/default/css/main.css
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.1/themes/default/css/main.css
@@ -1,0 +1,607 @@
+body { margin: 0; }
+body .ui.menu { display: none; }
+body .ui.container { max-width: 1080px; margin: 0 auto; padding: 0 2rem; }
+/* signal-conf theme overlay on the semantic-ui default theme.
+ *
+ * Semantic UI has a strong built-in look, but Kestros components
+ * can't pass UIKit-style modifier classes through inlineVariations
+ * (it's a variation-name lookup, not raw class pass-through). So
+ * this file targets the concrete markup the signal-conf site emits
+ * and applies the finishing layer directly — dark conference hero,
+ * bold editorial typography, card grids for speakers/sessions, and
+ * a sticky schedule table.
+ */
+
+/* ─── Base typography ─────────────────────────────────────────────────── */
+body {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Roboto, Helvetica, Arial, sans-serif;
+  color: #1a1d26;
+  background: #ffffff;
+  line-height: 1.55;
+}
+a { color: #e8513f; text-decoration: none; }
+a:hover { color: #b33626; }
+h1, h2, h3, h4 { font-family: 'Inter', -apple-system, sans-serif; color: #0b0d14; }
+
+/* ─── Top navigation ──────────────────────────────────────────────────── */
+body > div.component-inherited-content-area:first-of-type {
+  background: #0b0d14;
+  padding: 1.1rem 2.5rem;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  border-bottom: 1px solid #1e2130;
+}
+body > div.component-inherited-content-area:first-of-type::before {
+  content: 'SIGNAL';
+  position: absolute;
+  left: 2.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-weight: 900;
+  letter-spacing: 0.22em;
+  font-size: 1rem;
+  color: #e8513f;
+}
+body > div.component-inherited-content-area:first-of-type .ui.menu,
+body > div.component-inherited-content-area:first-of-type .ui.menu .item {
+  background: transparent !important;
+  border: none !important;
+  padding-left: 0;
+}
+body > div.component-inherited-content-area:first-of-type a {
+  color: #c8cbd6;
+  text-decoration: none;
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  margin-left: 1.75rem;
+}
+body > div.component-inherited-content-area:first-of-type a:hover {
+  color: #ffffff;
+}
+/* Push the nav items to the right to leave room for the SIGNAL wordmark */
+body > div.component-inherited-content-area:first-of-type > .component-content-area,
+body > div.component-inherited-content-area:first-of-type > div:not(.component-inherited-content-area) {
+  text-align: right;
+}
+
+/* ─── Sections — first is hero, rest alternate ────────────────────────── */
+body > div:not(.component-inherited-content-area),
+body > div.ui.container,
+body > section,
+body > div[class*="section"] {
+  /* noop — Kestros structure/section outputs some vendor-specific class */
+}
+
+/* The Kestros structure/section HTL on semantic-ui wraps content in a
+ * <div class="ui segment ${section.inlineVariations}">. We want full-
+ * bleed hero + regular content sections. */
+body > div:not(.component-inherited-content-area) {
+  padding: 4rem 2rem;
+  background: #ffffff;
+  border: none !important;
+  box-shadow: none !important;
+  margin: 0 !important;
+  border-radius: 0 !important;
+}
+
+/* First segment after header — dark editorial hero */
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) {
+  background: #0b0d14 !important;
+  color: #ffffff;
+  padding: 8rem 2rem 7rem;
+  position: relative;
+  overflow: hidden;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area)::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 18% 28%, rgba(232, 81, 63, 0.25) 0%, transparent 45%),
+    radial-gradient(circle at 82% 72%, rgba(76, 127, 226, 0.22) 0%, transparent 45%),
+    radial-gradient(circle at 50% 100%, rgba(255, 183, 77, 0.12) 0%, transparent 55%);
+  pointer-events: none;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) > * {
+  position: relative;
+  z-index: 1;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) h1 {
+  color: #ffffff;
+  font-size: 4.25rem;
+  line-height: 0.98;
+  letter-spacing: -0.035em;
+  font-weight: 900;
+  margin: 1rem auto 1.25rem;
+  max-width: 1000px;
+  text-align: center;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) h2 {
+  color: #ffffff;
+  font-size: 2.75rem;
+  line-height: 1;
+  font-weight: 800;
+  text-align: center;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) p {
+  color: rgba(255, 255, 255, 0.78);
+  font-size: 1.2rem;
+  max-width: 720px;
+  margin: 0.75rem auto 1.5rem;
+  text-align: center;
+  line-height: 1.55;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) .component-text:first-child p {
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  font-size: 0.8rem;
+  color: #e8513f;
+  margin-bottom: 0.25rem;
+}
+
+/* Non-hero section containers */
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) {
+  background: #ffffff;
+}
+body > div:nth-child(4):not(.component-inherited-content-area),
+body > div:nth-child(6):not(.component-inherited-content-area),
+body > div:nth-child(8):not(.component-inherited-content-area),
+body > div:nth-child(10):not(.component-inherited-content-area),
+body > div:nth-child(12):not(.component-inherited-content-area),
+body > div:nth-child(14):not(.component-inherited-content-area) {
+  background: #f5f6fa;
+}
+
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) h2 {
+  font-size: 2.25rem;
+  font-weight: 800;
+  letter-spacing: -0.015em;
+  text-align: center;
+  margin: 0 auto 2rem;
+  max-width: 800px;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) .component-text:first-child p {
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.78rem;
+  color: #e8513f;
+  font-weight: 700;
+  margin-bottom: 0.4rem;
+}
+
+body > div:not(.component-inherited-content-area) > .ui.container {
+  max-width: 1080px;
+  margin: 0 auto;
+}
+
+/* ─── Button group → conference pill buttons ──────────────────────────── */
+body div[class*="uk-button-group"],
+body .component-button-group {
+  text-align: center;
+  margin-top: 1.75rem;
+}
+body a.ui.button,
+body .component-button-group a {
+  display: inline-block;
+  background: #e8513f;
+  color: #ffffff !important;
+  padding: 0.95rem 1.85rem;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  text-decoration: none;
+  margin: 0 0.4rem 0 0;
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+body a.ui.button:hover,
+body .component-button-group a:hover {
+  background: #b33626;
+  transform: translateY(-1px);
+}
+body .component-button-group a + a {
+  background: transparent;
+  color: #ffffff !important;
+  border: 1px solid rgba(255, 255, 255, 0.55);
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) .component-button-group a + a {
+  color: #0b0d14 !important;
+  border: 1px solid #0b0d14;
+}
+
+/* ─── Richtext flex/grid handling (see league-theme for rationale) ────── */
+body .component-richtext > div > div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  margin: 1.5rem auto 0;
+  justify-content: center;
+}
+body .component-richtext > div > div > table,
+body .component-richtext > div > table,
+body .component-richtext > div > ul,
+body .component-richtext > div > ol,
+body .component-richtext > div > h2,
+body .component-richtext > div > h3,
+body .component-richtext > div > h4,
+body .component-richtext > div > p {
+  display: initial;
+}
+body .component-richtext > div:has(> table),
+body .component-richtext > div:has(> ul),
+body .component-richtext > div:has(> ol),
+body .component-richtext > div:has(> h2),
+body .component-richtext > div:has(> h3) {
+  display: block;
+}
+
+/* Sponsors & schedule-day blocks need block layout (full-width tiers
+ * and day tables, not a flex row of tiers). */
+body .component-richtext > div > div:has(> .sponsors-tier),
+body .component-richtext > div > div:has(> .schedule-day),
+body .component-richtext > div > div:has(> table),
+body .component-richtext > div > div:has(> .past-editions-table) {
+  display: block;
+}
+body .component-richtext > div > div > div:not([class*="ui-grid"]):not([class*="uk-grid"]):not([class*="uk-child-width"]):not([class*="uk-flex"]):not(.sponsors-tier):not(.schedule-day):not(.signal-venue):not(.signal-stat-grid) {
+  flex: 1 1 280px;
+  max-width: 340px;
+}
+/* Full-width blocks inside a block-display wrapper */
+body .component-richtext > div > div > .sponsors-tier,
+body .component-richtext > div > div > .schedule-day,
+body .component-richtext > div > div > .signal-venue,
+body .component-richtext > div > div > .signal-stat-grid {
+  flex: none;
+  max-width: none;
+  width: 100%;
+}
+
+/* ─── Cards (speakers / sessions / sponsors) ──────────────────────────── */
+body .signal-card {
+  background: #ffffff;
+  border: 1px solid #e2e4ec;
+  border-radius: 14px;
+  padding: 1.5rem 1.4rem;
+  box-shadow: 0 1px 2px rgba(20, 24, 36, 0.03);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+body .signal-card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 14px 32px rgba(20, 24, 36, 0.09);
+  border-color: #cdd1dc;
+}
+body .signal-card h3 {
+  margin: 0.1rem 0 0;
+  font-size: 1.2rem;
+  font-weight: 800;
+  color: #0b0d14;
+  letter-spacing: -0.01em;
+}
+body .signal-card .signal-card-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.68rem;
+  color: #e8513f;
+  font-weight: 700;
+}
+body .signal-card .signal-card-sub {
+  color: #5c6376;
+  font-size: 0.92rem;
+}
+body .signal-card .signal-card-body {
+  color: #3a404f;
+  font-size: 0.92rem;
+  margin-top: 0.35rem;
+}
+body .signal-card .signal-card-foot {
+  margin-top: auto;
+  padding-top: 0.75rem;
+  border-top: 1px solid #eef0f5;
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  color: #5c6376;
+}
+body .signal-card .signal-tag {
+  display: inline-block;
+  background: #f1f2f7;
+  color: #3a404f;
+  padding: 0.15rem 0.6rem;
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-radius: 999px;
+}
+body .signal-card .signal-tag.is-intro       { background: #e9f6ef; color: #1d7041; }
+body .signal-card .signal-tag.is-intermediate{ background: #fdf4d6; color: #7a5512; }
+body .signal-card .signal-tag.is-advanced    { background: #fbe5e2; color: #8a2418; }
+
+/* Speaker avatar = initials circle on a brand-red disc */
+body .signal-avatar {
+  width: 56px;
+  height: 56px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #e8513f, #b33626);
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 900;
+  font-size: 1.15rem;
+  letter-spacing: 0.02em;
+  flex-shrink: 0;
+}
+
+/* ─── Schedule table ──────────────────────────────────────────────────── */
+body .schedule-day {
+  margin: 2rem auto 2.5rem;
+}
+body .schedule-day h3 {
+  text-align: center;
+  font-size: 1.55rem;
+  font-weight: 800;
+  color: #0b0d14;
+  margin: 0 0 1rem;
+  letter-spacing: -0.01em;
+}
+body table.schedule-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92rem;
+  background: #ffffff;
+  border: 1px solid #e2e4ec;
+  border-radius: 12px;
+  overflow: hidden;
+}
+body table.schedule-table thead th {
+  background: #0b0d14;
+  color: #ffffff;
+  text-align: left;
+  padding: 0.85rem 1rem;
+  font-weight: 700;
+  font-size: 0.76rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+body table.schedule-table td {
+  padding: 0.95rem 1rem;
+  border-bottom: 1px solid #e8eaf0;
+  vertical-align: top;
+}
+body table.schedule-table tr:last-child td { border-bottom: none; }
+body table.schedule-table tr:nth-child(even) td { background: #f8f9fc; }
+body table.schedule-table td.schedule-time {
+  font-weight: 700;
+  color: #0b0d14;
+  white-space: nowrap;
+  width: 110px;
+}
+body table.schedule-table td.schedule-track {
+  color: #5c6376;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+  width: 130px;
+}
+body table.schedule-table td.schedule-title strong {
+  display: block;
+  color: #0b0d14;
+  font-size: 1rem;
+  font-weight: 700;
+}
+body table.schedule-table td.schedule-title .schedule-speaker {
+  color: #5c6376;
+  font-size: 0.85rem;
+  margin-top: 0.15rem;
+}
+
+/* ─── Session + speaker + venue details ───────────────────────────────── */
+body .signal-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  max-width: 900px;
+  margin: 1.5rem auto;
+}
+body .signal-stat-grid .signal-stat {
+  background: #ffffff;
+  border: 1px solid #e2e4ec;
+  border-radius: 12px;
+  padding: 1.35rem 1.2rem;
+  text-align: center;
+}
+body .signal-stat .signal-stat-label {
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.7rem;
+  color: #5c6376;
+  font-weight: 700;
+}
+body .signal-stat .signal-stat-value {
+  font-size: 2rem;
+  font-weight: 900;
+  color: #0b0d14;
+  margin-top: 0.3rem;
+  letter-spacing: -0.015em;
+}
+
+/* ─── Sponsors tier grid ──────────────────────────────────────────────── */
+body .sponsors-tier {
+  text-align: center;
+  margin: 1.75rem 0;
+}
+body .sponsors-tier h3 {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: #5c6376;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+body .sponsor-logos {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 1.5rem;
+}
+body .sponsor-logos .sponsor {
+  background: #ffffff;
+  border: 1px solid #e2e4ec;
+  border-radius: 12px;
+  padding: 1rem 1.6rem;
+  font-weight: 800;
+  color: #0b0d14;
+  letter-spacing: -0.01em;
+  min-width: 160px;
+  text-align: center;
+}
+body .sponsor-logos .sponsor.tier-gold { font-size: 1.4rem; padding: 1.6rem 2.2rem; }
+body .sponsor-logos .sponsor.tier-silver { font-size: 1.1rem; padding: 1.2rem 1.8rem; }
+body .sponsor-logos .sponsor.tier-bronze { font-size: 0.95rem; opacity: 0.85; }
+
+/* ─── Venue map-ish block ─────────────────────────────────────────────── */
+body .signal-venue {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+  max-width: 960px;
+  margin: 1.5rem auto;
+  align-items: stretch;
+}
+body .signal-venue .signal-venue-map {
+  background: linear-gradient(135deg, #0b0d14 0%, #1c2133 60%, #2d3657 100%);
+  border-radius: 16px;
+  min-height: 340px;
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #ffffff;
+}
+body .signal-venue .signal-venue-map::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(135deg, transparent 48%, rgba(232, 81, 63, 0.12) 48%, rgba(232, 81, 63, 0.12) 52%, transparent 52%),
+    linear-gradient(45deg, transparent 48%, rgba(76, 127, 226, 0.1) 48%, rgba(76, 127, 226, 0.1) 52%, transparent 52%);
+}
+body .signal-venue .signal-venue-map .signal-venue-pin {
+  position: relative;
+  z-index: 1;
+  background: #e8513f;
+  border-radius: 999px;
+  padding: 0.6rem 1.2rem;
+  font-weight: 800;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  box-shadow: 0 6px 18px rgba(232, 81, 63, 0.4);
+}
+body .signal-venue .signal-venue-info h3 {
+  font-size: 1.4rem;
+  margin: 0 0 0.5rem;
+}
+body .signal-venue .signal-venue-info p {
+  color: #3a404f;
+  margin: 0 0 1rem;
+  line-height: 1.55;
+}
+
+/* ─── Footer ──────────────────────────────────────────────────────────── */
+body > div.component-inherited-content-area:last-of-type {
+  background: #0b0d14;
+  color: rgba(255, 255, 255, 0.72);
+  padding: 3.5rem 2rem 2rem;
+}
+body > div.component-inherited-content-area:last-of-type .ui.segment,
+body > div.component-inherited-content-area:last-of-type > div[class*="segment"] {
+  background: transparent !important;
+  padding: 0 !important;
+}
+body > div.component-inherited-content-area:last-of-type h4,
+body > div.component-inherited-content-area:last-of-type h5 {
+  color: #ffffff;
+  font-size: 0.82rem;
+  margin: 0 0 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 700;
+}
+body > div.component-inherited-content-area:last-of-type a {
+  color: rgba(255, 255, 255, 0.72);
+}
+body > div.component-inherited-content-area:last-of-type a:hover {
+  color: #ffffff;
+}
+body > div.component-inherited-content-area:last-of-type ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+body > div.component-inherited-content-area:last-of-type li {
+  padding: 0.25rem 0;
+  font-size: 0.88rem;
+}
+body > div.component-inherited-content-area:last-of-type .component-richtext > div > div {
+  display: grid !important;
+  grid-template-columns: 2fr 1fr 1fr 1fr;
+  gap: 2rem;
+  max-width: 1080px;
+  margin: 0 auto;
+}
+body > div.component-inherited-content-area:last-of-type .component-richtext > div > div > div {
+  max-width: none !important;
+  flex: none !important;
+}
+body > div.component-inherited-content-area:last-of-type hr {
+  border: none;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  margin: 2rem 0 1rem;
+  max-width: 1080px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* ─── Past-editions table ─────────────────────────────────────────────── */
+body .past-editions-table {
+  width: 100%;
+  max-width: 860px;
+  margin: 1rem auto;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+body .past-editions-table td,
+body .past-editions-table th {
+  padding: 0.85rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid #e8eaf0;
+}
+body .past-editions-table th {
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 0.76rem;
+  letter-spacing: 0.08em;
+  color: #5c6376;
+}
+body .past-editions-table strong { color: #0b0d14; }
+
+/* ─── Small utilities the pages use ───────────────────────────────────── */
+body .signal-center { text-align: center; }
+body .signal-muted { color: #5c6376; }
+body .signal-strong { font-weight: 700; color: #0b0d14; }
+

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.2/.content.xml
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.2/.content.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:kes="http://kestros.io/kes/1.0"
+          jcr:primaryType="kes:UiFramework"
+          jcr:title="Signal Framework 0.0.2"
+          jcr:description="Brand pass — editorial red/indigo palette with an aurora hero treatment."
+          kes:uiFrameworkCode="signal-framework"
+          kes:vendorLibraries="[ui-kit/3.23.6]"
+/>

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.2/themes/default/.content.xml
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.2/themes/default/.content.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:kes="http://kestros.io/kes/1.0"
+          jcr:primaryType="kes:Theme"
+          jcr:title="Default"
+/>

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.2/themes/default/css/.content.xml
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.2/themes/default/css/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="sling:OrderedFolder"
+          include="[main.css]"
+/>

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.2/themes/default/css/main.css
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.2/themes/default/css/main.css
@@ -1,0 +1,678 @@
+body { margin: 0; }
+body .ui.menu { display: none; }
+body .ui.container { max-width: 1080px; margin: 0 auto; padding: 0 2rem; }
+/* signal-conf theme overlay on the semantic-ui default theme.
+ *
+ * Semantic UI has a strong built-in look, but Kestros components
+ * can't pass UIKit-style modifier classes through inlineVariations
+ * (it's a variation-name lookup, not raw class pass-through). So
+ * this file targets the concrete markup the signal-conf site emits
+ * and applies the finishing layer directly — dark conference hero,
+ * bold editorial typography, card grids for speakers/sessions, and
+ * a sticky schedule table.
+ */
+
+/* ─── Base typography ─────────────────────────────────────────────────── */
+body {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Roboto, Helvetica, Arial, sans-serif;
+  color: #1a1d26;
+  background: #ffffff;
+  line-height: 1.55;
+}
+a { color: #e8513f; text-decoration: none; }
+a:hover { color: #b33626; }
+h1, h2, h3, h4 { font-family: 'Inter', -apple-system, sans-serif; color: #0b0d14; }
+
+/* ─── Top navigation ──────────────────────────────────────────────────── */
+body > div.component-inherited-content-area:first-of-type {
+  background: #0b0d14;
+  padding: 1.1rem 2.5rem;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  border-bottom: 1px solid #1e2130;
+}
+body > div.component-inherited-content-area:first-of-type::before {
+  content: 'SIGNAL';
+  position: absolute;
+  left: 2.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-weight: 900;
+  letter-spacing: 0.22em;
+  font-size: 1rem;
+  color: #e8513f;
+}
+body > div.component-inherited-content-area:first-of-type .ui.menu,
+body > div.component-inherited-content-area:first-of-type .ui.menu .item {
+  background: transparent !important;
+  border: none !important;
+  padding-left: 0;
+}
+body > div.component-inherited-content-area:first-of-type a {
+  color: #c8cbd6;
+  text-decoration: none;
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  margin-left: 1.75rem;
+}
+body > div.component-inherited-content-area:first-of-type a:hover {
+  color: #ffffff;
+}
+/* Push the nav items to the right to leave room for the SIGNAL wordmark */
+body > div.component-inherited-content-area:first-of-type > .component-content-area,
+body > div.component-inherited-content-area:first-of-type > div:not(.component-inherited-content-area) {
+  text-align: right;
+}
+
+/* ─── Sections — first is hero, rest alternate ────────────────────────── */
+body > div:not(.component-inherited-content-area),
+body > div.ui.container,
+body > section,
+body > div[class*="section"] {
+  /* noop — Kestros structure/section outputs some vendor-specific class */
+}
+
+/* The Kestros structure/section HTL on semantic-ui wraps content in a
+ * <div class="ui segment ${section.inlineVariations}">. We want full-
+ * bleed hero + regular content sections. */
+body > div:not(.component-inherited-content-area) {
+  padding: 4rem 2rem;
+  background: #ffffff;
+  border: none !important;
+  box-shadow: none !important;
+  margin: 0 !important;
+  border-radius: 0 !important;
+}
+
+/* First segment after header — dark editorial hero */
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) {
+  background: #0b0d14 !important;
+  color: #ffffff;
+  padding: 8rem 2rem 7rem;
+  position: relative;
+  overflow: hidden;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area)::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 18% 28%, rgba(232, 81, 63, 0.25) 0%, transparent 45%),
+    radial-gradient(circle at 82% 72%, rgba(76, 127, 226, 0.22) 0%, transparent 45%),
+    radial-gradient(circle at 50% 100%, rgba(255, 183, 77, 0.12) 0%, transparent 55%);
+  pointer-events: none;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) > * {
+  position: relative;
+  z-index: 1;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) h1 {
+  color: #ffffff;
+  font-size: 4.25rem;
+  line-height: 0.98;
+  letter-spacing: -0.035em;
+  font-weight: 900;
+  margin: 1rem auto 1.25rem;
+  max-width: 1000px;
+  text-align: center;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) h2 {
+  color: #ffffff;
+  font-size: 2.75rem;
+  line-height: 1;
+  font-weight: 800;
+  text-align: center;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) p {
+  color: rgba(255, 255, 255, 0.78);
+  font-size: 1.2rem;
+  max-width: 720px;
+  margin: 0.75rem auto 1.5rem;
+  text-align: center;
+  line-height: 1.55;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) .component-text:first-child p {
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  font-size: 0.8rem;
+  color: #e8513f;
+  margin-bottom: 0.25rem;
+}
+
+/* Non-hero section containers */
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) {
+  background: #ffffff;
+}
+body > div:nth-child(4):not(.component-inherited-content-area),
+body > div:nth-child(6):not(.component-inherited-content-area),
+body > div:nth-child(8):not(.component-inherited-content-area),
+body > div:nth-child(10):not(.component-inherited-content-area),
+body > div:nth-child(12):not(.component-inherited-content-area),
+body > div:nth-child(14):not(.component-inherited-content-area) {
+  background: #f5f6fa;
+}
+
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) h2 {
+  font-size: 2.25rem;
+  font-weight: 800;
+  letter-spacing: -0.015em;
+  text-align: center;
+  margin: 0 auto 2rem;
+  max-width: 800px;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) .component-text:first-child p {
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.78rem;
+  color: #e8513f;
+  font-weight: 700;
+  margin-bottom: 0.4rem;
+}
+
+body > div:not(.component-inherited-content-area) > .ui.container {
+  max-width: 1080px;
+  margin: 0 auto;
+}
+
+/* ─── Button group → conference pill buttons ──────────────────────────── */
+body div[class*="uk-button-group"],
+body .component-button-group {
+  text-align: center;
+  margin-top: 1.75rem;
+}
+body a.ui.button,
+body .component-button-group a {
+  display: inline-block;
+  background: #e8513f;
+  color: #ffffff !important;
+  padding: 0.95rem 1.85rem;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  text-decoration: none;
+  margin: 0 0.4rem 0 0;
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+body a.ui.button:hover,
+body .component-button-group a:hover {
+  background: #b33626;
+  transform: translateY(-1px);
+}
+body .component-button-group a + a {
+  background: transparent;
+  color: #ffffff !important;
+  border: 1px solid rgba(255, 255, 255, 0.55);
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) .component-button-group a + a {
+  color: #0b0d14 !important;
+  border: 1px solid #0b0d14;
+}
+
+/* ─── Richtext flex/grid handling (see league-theme for rationale) ────── */
+body .component-richtext > div > div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  margin: 1.5rem auto 0;
+  justify-content: center;
+}
+body .component-richtext > div > div > table,
+body .component-richtext > div > table,
+body .component-richtext > div > ul,
+body .component-richtext > div > ol,
+body .component-richtext > div > h2,
+body .component-richtext > div > h3,
+body .component-richtext > div > h4,
+body .component-richtext > div > p {
+  display: initial;
+}
+body .component-richtext > div:has(> table),
+body .component-richtext > div:has(> ul),
+body .component-richtext > div:has(> ol),
+body .component-richtext > div:has(> h2),
+body .component-richtext > div:has(> h3) {
+  display: block;
+}
+
+/* Sponsors & schedule-day blocks need block layout (full-width tiers
+ * and day tables, not a flex row of tiers). */
+body .component-richtext > div > div:has(> .sponsors-tier),
+body .component-richtext > div > div:has(> .schedule-day),
+body .component-richtext > div > div:has(> table),
+body .component-richtext > div > div:has(> .past-editions-table) {
+  display: block;
+}
+body .component-richtext > div > div > div:not([class*="ui-grid"]):not([class*="uk-grid"]):not([class*="uk-child-width"]):not([class*="uk-flex"]):not(.sponsors-tier):not(.schedule-day):not(.signal-venue):not(.signal-stat-grid) {
+  flex: 1 1 280px;
+  max-width: 340px;
+}
+/* Full-width blocks inside a block-display wrapper */
+body .component-richtext > div > div > .sponsors-tier,
+body .component-richtext > div > div > .schedule-day,
+body .component-richtext > div > div > .signal-venue,
+body .component-richtext > div > div > .signal-stat-grid {
+  flex: none;
+  max-width: none;
+  width: 100%;
+}
+
+/* ─── Cards (speakers / sessions / sponsors) ──────────────────────────── */
+body .signal-card {
+  background: #ffffff;
+  border: 1px solid #e2e4ec;
+  border-radius: 14px;
+  padding: 1.5rem 1.4rem;
+  box-shadow: 0 1px 2px rgba(20, 24, 36, 0.03);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+body .signal-card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 14px 32px rgba(20, 24, 36, 0.09);
+  border-color: #cdd1dc;
+}
+body .signal-card h3 {
+  margin: 0.1rem 0 0;
+  font-size: 1.2rem;
+  font-weight: 800;
+  color: #0b0d14;
+  letter-spacing: -0.01em;
+}
+body .signal-card .signal-card-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.68rem;
+  color: #e8513f;
+  font-weight: 700;
+}
+body .signal-card .signal-card-sub {
+  color: #5c6376;
+  font-size: 0.92rem;
+}
+body .signal-card .signal-card-body {
+  color: #3a404f;
+  font-size: 0.92rem;
+  margin-top: 0.35rem;
+}
+body .signal-card .signal-card-foot {
+  margin-top: auto;
+  padding-top: 0.75rem;
+  border-top: 1px solid #eef0f5;
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  color: #5c6376;
+}
+body .signal-card .signal-tag {
+  display: inline-block;
+  background: #f1f2f7;
+  color: #3a404f;
+  padding: 0.15rem 0.6rem;
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-radius: 999px;
+}
+body .signal-card .signal-tag.is-intro       { background: #e9f6ef; color: #1d7041; }
+body .signal-card .signal-tag.is-intermediate{ background: #fdf4d6; color: #7a5512; }
+body .signal-card .signal-tag.is-advanced    { background: #fbe5e2; color: #8a2418; }
+
+/* Speaker avatar = initials circle on a brand-red disc */
+body .signal-avatar {
+  width: 56px;
+  height: 56px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #e8513f, #b33626);
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 900;
+  font-size: 1.15rem;
+  letter-spacing: 0.02em;
+  flex-shrink: 0;
+}
+
+/* ─── Schedule table ──────────────────────────────────────────────────── */
+body .schedule-day {
+  margin: 2rem auto 2.5rem;
+}
+body .schedule-day h3 {
+  text-align: center;
+  font-size: 1.55rem;
+  font-weight: 800;
+  color: #0b0d14;
+  margin: 0 0 1rem;
+  letter-spacing: -0.01em;
+}
+body table.schedule-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92rem;
+  background: #ffffff;
+  border: 1px solid #e2e4ec;
+  border-radius: 12px;
+  overflow: hidden;
+}
+body table.schedule-table thead th {
+  background: #0b0d14;
+  color: #ffffff;
+  text-align: left;
+  padding: 0.85rem 1rem;
+  font-weight: 700;
+  font-size: 0.76rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+body table.schedule-table td {
+  padding: 0.95rem 1rem;
+  border-bottom: 1px solid #e8eaf0;
+  vertical-align: top;
+}
+body table.schedule-table tr:last-child td { border-bottom: none; }
+body table.schedule-table tr:nth-child(even) td { background: #f8f9fc; }
+body table.schedule-table td.schedule-time {
+  font-weight: 700;
+  color: #0b0d14;
+  white-space: nowrap;
+  width: 110px;
+}
+body table.schedule-table td.schedule-track {
+  color: #5c6376;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+  width: 130px;
+}
+body table.schedule-table td.schedule-title strong {
+  display: block;
+  color: #0b0d14;
+  font-size: 1rem;
+  font-weight: 700;
+}
+body table.schedule-table td.schedule-title .schedule-speaker {
+  color: #5c6376;
+  font-size: 0.85rem;
+  margin-top: 0.15rem;
+}
+
+/* ─── Session + speaker + venue details ───────────────────────────────── */
+body .signal-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  max-width: 900px;
+  margin: 1.5rem auto;
+}
+body .signal-stat-grid .signal-stat {
+  background: #ffffff;
+  border: 1px solid #e2e4ec;
+  border-radius: 12px;
+  padding: 1.35rem 1.2rem;
+  text-align: center;
+}
+body .signal-stat .signal-stat-label {
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.7rem;
+  color: #5c6376;
+  font-weight: 700;
+}
+body .signal-stat .signal-stat-value {
+  font-size: 2rem;
+  font-weight: 900;
+  color: #0b0d14;
+  margin-top: 0.3rem;
+  letter-spacing: -0.015em;
+}
+
+/* ─── Sponsors tier grid ──────────────────────────────────────────────── */
+body .sponsors-tier {
+  text-align: center;
+  margin: 1.75rem 0;
+}
+body .sponsors-tier h3 {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: #5c6376;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+body .sponsor-logos {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 1.5rem;
+}
+body .sponsor-logos .sponsor {
+  background: #ffffff;
+  border: 1px solid #e2e4ec;
+  border-radius: 12px;
+  padding: 1rem 1.6rem;
+  font-weight: 800;
+  color: #0b0d14;
+  letter-spacing: -0.01em;
+  min-width: 160px;
+  text-align: center;
+}
+body .sponsor-logos .sponsor.tier-gold { font-size: 1.4rem; padding: 1.6rem 2.2rem; }
+body .sponsor-logos .sponsor.tier-silver { font-size: 1.1rem; padding: 1.2rem 1.8rem; }
+body .sponsor-logos .sponsor.tier-bronze { font-size: 0.95rem; opacity: 0.85; }
+
+/* ─── Venue map-ish block ─────────────────────────────────────────────── */
+body .signal-venue {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+  max-width: 960px;
+  margin: 1.5rem auto;
+  align-items: stretch;
+}
+body .signal-venue .signal-venue-map {
+  background: linear-gradient(135deg, #0b0d14 0%, #1c2133 60%, #2d3657 100%);
+  border-radius: 16px;
+  min-height: 340px;
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #ffffff;
+}
+body .signal-venue .signal-venue-map::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(135deg, transparent 48%, rgba(232, 81, 63, 0.12) 48%, rgba(232, 81, 63, 0.12) 52%, transparent 52%),
+    linear-gradient(45deg, transparent 48%, rgba(76, 127, 226, 0.1) 48%, rgba(76, 127, 226, 0.1) 52%, transparent 52%);
+}
+body .signal-venue .signal-venue-map .signal-venue-pin {
+  position: relative;
+  z-index: 1;
+  background: #e8513f;
+  border-radius: 999px;
+  padding: 0.6rem 1.2rem;
+  font-weight: 800;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  box-shadow: 0 6px 18px rgba(232, 81, 63, 0.4);
+}
+body .signal-venue .signal-venue-info h3 {
+  font-size: 1.4rem;
+  margin: 0 0 0.5rem;
+}
+body .signal-venue .signal-venue-info p {
+  color: #3a404f;
+  margin: 0 0 1rem;
+  line-height: 1.55;
+}
+
+/* ─── Footer ──────────────────────────────────────────────────────────── */
+body > div.component-inherited-content-area:last-of-type {
+  background: #0b0d14;
+  color: rgba(255, 255, 255, 0.72);
+  padding: 3.5rem 2rem 2rem;
+}
+body > div.component-inherited-content-area:last-of-type .ui.segment,
+body > div.component-inherited-content-area:last-of-type > div[class*="segment"] {
+  background: transparent !important;
+  padding: 0 !important;
+}
+body > div.component-inherited-content-area:last-of-type h4,
+body > div.component-inherited-content-area:last-of-type h5 {
+  color: #ffffff;
+  font-size: 0.82rem;
+  margin: 0 0 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 700;
+}
+body > div.component-inherited-content-area:last-of-type a {
+  color: rgba(255, 255, 255, 0.72);
+}
+body > div.component-inherited-content-area:last-of-type a:hover {
+  color: #ffffff;
+}
+body > div.component-inherited-content-area:last-of-type ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+body > div.component-inherited-content-area:last-of-type li {
+  padding: 0.25rem 0;
+  font-size: 0.88rem;
+}
+body > div.component-inherited-content-area:last-of-type .component-richtext > div > div {
+  display: grid !important;
+  grid-template-columns: 2fr 1fr 1fr 1fr;
+  gap: 2rem;
+  max-width: 1080px;
+  margin: 0 auto;
+}
+body > div.component-inherited-content-area:last-of-type .component-richtext > div > div > div {
+  max-width: none !important;
+  flex: none !important;
+}
+body > div.component-inherited-content-area:last-of-type hr {
+  border: none;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  margin: 2rem 0 1rem;
+  max-width: 1080px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* ─── Past-editions table ─────────────────────────────────────────────── */
+body .past-editions-table {
+  width: 100%;
+  max-width: 860px;
+  margin: 1rem auto;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+body .past-editions-table td,
+body .past-editions-table th {
+  padding: 0.85rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid #e8eaf0;
+}
+body .past-editions-table th {
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 0.76rem;
+  letter-spacing: 0.08em;
+  color: #5c6376;
+}
+body .past-editions-table strong { color: #0b0d14; }
+
+/* ─── Small utilities the pages use ───────────────────────────────────── */
+body .signal-center { text-align: center; }
+body .signal-muted { color: #5c6376; }
+body .signal-strong { font-weight: 700; color: #0b0d14; }
+
+
+/* ─── signal-framework 0.0.2 customizations ──────────────────────────
+ * Editorial indigo + red palette, serif display headlines, aurora hero. */
+:root {
+  --signal-primary:     #ff6a4a;
+  --signal-primary-dark:#c23b1d;
+  --signal-ink:         #070814;
+  --signal-indigo:      #1c1f46;
+  --signal-indigo-2:    #2a2e68;
+  --signal-cream:       #f8f5ee;
+}
+body { background: #ffffff; color: #1c1f2a; }
+body > div.component-inherited-content-area:first-of-type { background: var(--signal-ink); }
+body > div.component-inherited-content-area:first-of-type::before { color: var(--signal-primary); }
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) {
+  background: var(--signal-ink) !important;
+  padding: 9rem 2rem 8rem;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area)::before {
+  background:
+    radial-gradient(ellipse 60% 40% at 20% 30%, rgba(255, 106, 74, 0.28) 0%, transparent 60%),
+    radial-gradient(ellipse 50% 60% at 78% 68%, rgba(84, 70, 220, 0.32) 0%, transparent 55%),
+    radial-gradient(ellipse 70% 40% at 50% 100%, rgba(255, 182, 72, 0.14) 0%, transparent 60%),
+    linear-gradient(180deg, var(--signal-ink) 0%, var(--signal-indigo) 100%);
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) h1 {
+  font-family: 'Georgia', 'Libre Caslon Text', 'Baskerville', serif;
+  font-weight: 700;
+  font-size: 4.5rem;
+  letter-spacing: -0.025em;
+  line-height: 0.98;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) .component-text:first-child p {
+  color: var(--signal-primary);
+  font-family: -apple-system, 'Inter', sans-serif;
+  font-weight: 700;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) h2 {
+  font-family: 'Georgia', serif;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) .component-text:first-child p {
+  color: var(--signal-primary);
+}
+body a.ui.button,
+body .component-button-group a {
+  background: linear-gradient(135deg, var(--signal-primary) 0%, var(--signal-primary-dark) 100%);
+  box-shadow: 0 6px 18px rgba(255, 106, 74, 0.3);
+}
+body a.ui.button:hover,
+body .component-button-group a:hover {
+  background: linear-gradient(135deg, var(--signal-primary-dark) 0%, #8c220c 100%);
+}
+body > div:nth-child(4):not(.component-inherited-content-area),
+body > div:nth-child(6):not(.component-inherited-content-area),
+body > div:nth-child(8):not(.component-inherited-content-area),
+body > div:nth-child(10):not(.component-inherited-content-area),
+body > div:nth-child(12):not(.component-inherited-content-area),
+body > div:nth-child(14):not(.component-inherited-content-area) {
+  background: var(--signal-cream);
+}
+body .signal-card-eyebrow { color: var(--signal-primary); }
+body .signal-avatar { background: linear-gradient(135deg, var(--signal-primary), var(--signal-primary-dark)); }
+body a { color: var(--signal-primary); }
+body a:hover { color: var(--signal-primary-dark); }
+body table.schedule-table thead th { background: var(--signal-indigo); }
+body > div.component-inherited-content-area:last-of-type {
+  background: var(--signal-ink);
+  border-top: 3px solid var(--signal-primary);
+}

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.3/.content.xml
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.3/.content.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:kes="http://kestros.io/kes/1.0"
+          jcr:primaryType="kes:UiFramework"
+          jcr:title="Signal Framework 0.0.3"
+          jcr:description="Card elevation — session and speaker card shadows + border treatment."
+          kes:uiFrameworkCode="signal-framework"
+          kes:vendorLibraries="[ui-kit/3.23.6]"
+/>

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.3/themes/default/.content.xml
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.3/themes/default/.content.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:kes="http://kestros.io/kes/1.0"
+          jcr:primaryType="kes:Theme"
+          jcr:title="Default"
+/>

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.3/themes/default/css/.content.xml
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.3/themes/default/css/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="sling:OrderedFolder"
+          include="[main.css]"
+/>

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.3/themes/default/css/main.css
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.3/themes/default/css/main.css
@@ -1,0 +1,691 @@
+body { margin: 0; }
+body .ui.menu { display: none; }
+body .ui.container { max-width: 1080px; margin: 0 auto; padding: 0 2rem; }
+/* signal-conf theme overlay on the semantic-ui default theme.
+ *
+ * Semantic UI has a strong built-in look, but Kestros components
+ * can't pass UIKit-style modifier classes through inlineVariations
+ * (it's a variation-name lookup, not raw class pass-through). So
+ * this file targets the concrete markup the signal-conf site emits
+ * and applies the finishing layer directly — dark conference hero,
+ * bold editorial typography, card grids for speakers/sessions, and
+ * a sticky schedule table.
+ */
+
+/* ─── Base typography ─────────────────────────────────────────────────── */
+body {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Roboto, Helvetica, Arial, sans-serif;
+  color: #1a1d26;
+  background: #ffffff;
+  line-height: 1.55;
+}
+a { color: #e8513f; text-decoration: none; }
+a:hover { color: #b33626; }
+h1, h2, h3, h4 { font-family: 'Inter', -apple-system, sans-serif; color: #0b0d14; }
+
+/* ─── Top navigation ──────────────────────────────────────────────────── */
+body > div.component-inherited-content-area:first-of-type {
+  background: #0b0d14;
+  padding: 1.1rem 2.5rem;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  border-bottom: 1px solid #1e2130;
+}
+body > div.component-inherited-content-area:first-of-type::before {
+  content: 'SIGNAL';
+  position: absolute;
+  left: 2.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-weight: 900;
+  letter-spacing: 0.22em;
+  font-size: 1rem;
+  color: #e8513f;
+}
+body > div.component-inherited-content-area:first-of-type .ui.menu,
+body > div.component-inherited-content-area:first-of-type .ui.menu .item {
+  background: transparent !important;
+  border: none !important;
+  padding-left: 0;
+}
+body > div.component-inherited-content-area:first-of-type a {
+  color: #c8cbd6;
+  text-decoration: none;
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  margin-left: 1.75rem;
+}
+body > div.component-inherited-content-area:first-of-type a:hover {
+  color: #ffffff;
+}
+/* Push the nav items to the right to leave room for the SIGNAL wordmark */
+body > div.component-inherited-content-area:first-of-type > .component-content-area,
+body > div.component-inherited-content-area:first-of-type > div:not(.component-inherited-content-area) {
+  text-align: right;
+}
+
+/* ─── Sections — first is hero, rest alternate ────────────────────────── */
+body > div:not(.component-inherited-content-area),
+body > div.ui.container,
+body > section,
+body > div[class*="section"] {
+  /* noop — Kestros structure/section outputs some vendor-specific class */
+}
+
+/* The Kestros structure/section HTL on semantic-ui wraps content in a
+ * <div class="ui segment ${section.inlineVariations}">. We want full-
+ * bleed hero + regular content sections. */
+body > div:not(.component-inherited-content-area) {
+  padding: 4rem 2rem;
+  background: #ffffff;
+  border: none !important;
+  box-shadow: none !important;
+  margin: 0 !important;
+  border-radius: 0 !important;
+}
+
+/* First segment after header — dark editorial hero */
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) {
+  background: #0b0d14 !important;
+  color: #ffffff;
+  padding: 8rem 2rem 7rem;
+  position: relative;
+  overflow: hidden;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area)::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 18% 28%, rgba(232, 81, 63, 0.25) 0%, transparent 45%),
+    radial-gradient(circle at 82% 72%, rgba(76, 127, 226, 0.22) 0%, transparent 45%),
+    radial-gradient(circle at 50% 100%, rgba(255, 183, 77, 0.12) 0%, transparent 55%);
+  pointer-events: none;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) > * {
+  position: relative;
+  z-index: 1;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) h1 {
+  color: #ffffff;
+  font-size: 4.25rem;
+  line-height: 0.98;
+  letter-spacing: -0.035em;
+  font-weight: 900;
+  margin: 1rem auto 1.25rem;
+  max-width: 1000px;
+  text-align: center;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) h2 {
+  color: #ffffff;
+  font-size: 2.75rem;
+  line-height: 1;
+  font-weight: 800;
+  text-align: center;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) p {
+  color: rgba(255, 255, 255, 0.78);
+  font-size: 1.2rem;
+  max-width: 720px;
+  margin: 0.75rem auto 1.5rem;
+  text-align: center;
+  line-height: 1.55;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) .component-text:first-child p {
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  font-size: 0.8rem;
+  color: #e8513f;
+  margin-bottom: 0.25rem;
+}
+
+/* Non-hero section containers */
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) {
+  background: #ffffff;
+}
+body > div:nth-child(4):not(.component-inherited-content-area),
+body > div:nth-child(6):not(.component-inherited-content-area),
+body > div:nth-child(8):not(.component-inherited-content-area),
+body > div:nth-child(10):not(.component-inherited-content-area),
+body > div:nth-child(12):not(.component-inherited-content-area),
+body > div:nth-child(14):not(.component-inherited-content-area) {
+  background: #f5f6fa;
+}
+
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) h2 {
+  font-size: 2.25rem;
+  font-weight: 800;
+  letter-spacing: -0.015em;
+  text-align: center;
+  margin: 0 auto 2rem;
+  max-width: 800px;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) .component-text:first-child p {
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.78rem;
+  color: #e8513f;
+  font-weight: 700;
+  margin-bottom: 0.4rem;
+}
+
+body > div:not(.component-inherited-content-area) > .ui.container {
+  max-width: 1080px;
+  margin: 0 auto;
+}
+
+/* ─── Button group → conference pill buttons ──────────────────────────── */
+body div[class*="uk-button-group"],
+body .component-button-group {
+  text-align: center;
+  margin-top: 1.75rem;
+}
+body a.ui.button,
+body .component-button-group a {
+  display: inline-block;
+  background: #e8513f;
+  color: #ffffff !important;
+  padding: 0.95rem 1.85rem;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  text-decoration: none;
+  margin: 0 0.4rem 0 0;
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+body a.ui.button:hover,
+body .component-button-group a:hover {
+  background: #b33626;
+  transform: translateY(-1px);
+}
+body .component-button-group a + a {
+  background: transparent;
+  color: #ffffff !important;
+  border: 1px solid rgba(255, 255, 255, 0.55);
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) .component-button-group a + a {
+  color: #0b0d14 !important;
+  border: 1px solid #0b0d14;
+}
+
+/* ─── Richtext flex/grid handling (see league-theme for rationale) ────── */
+body .component-richtext > div > div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  margin: 1.5rem auto 0;
+  justify-content: center;
+}
+body .component-richtext > div > div > table,
+body .component-richtext > div > table,
+body .component-richtext > div > ul,
+body .component-richtext > div > ol,
+body .component-richtext > div > h2,
+body .component-richtext > div > h3,
+body .component-richtext > div > h4,
+body .component-richtext > div > p {
+  display: initial;
+}
+body .component-richtext > div:has(> table),
+body .component-richtext > div:has(> ul),
+body .component-richtext > div:has(> ol),
+body .component-richtext > div:has(> h2),
+body .component-richtext > div:has(> h3) {
+  display: block;
+}
+
+/* Sponsors & schedule-day blocks need block layout (full-width tiers
+ * and day tables, not a flex row of tiers). */
+body .component-richtext > div > div:has(> .sponsors-tier),
+body .component-richtext > div > div:has(> .schedule-day),
+body .component-richtext > div > div:has(> table),
+body .component-richtext > div > div:has(> .past-editions-table) {
+  display: block;
+}
+body .component-richtext > div > div > div:not([class*="ui-grid"]):not([class*="uk-grid"]):not([class*="uk-child-width"]):not([class*="uk-flex"]):not(.sponsors-tier):not(.schedule-day):not(.signal-venue):not(.signal-stat-grid) {
+  flex: 1 1 280px;
+  max-width: 340px;
+}
+/* Full-width blocks inside a block-display wrapper */
+body .component-richtext > div > div > .sponsors-tier,
+body .component-richtext > div > div > .schedule-day,
+body .component-richtext > div > div > .signal-venue,
+body .component-richtext > div > div > .signal-stat-grid {
+  flex: none;
+  max-width: none;
+  width: 100%;
+}
+
+/* ─── Cards (speakers / sessions / sponsors) ──────────────────────────── */
+body .signal-card {
+  background: #ffffff;
+  border: 1px solid #e2e4ec;
+  border-radius: 14px;
+  padding: 1.5rem 1.4rem;
+  box-shadow: 0 1px 2px rgba(20, 24, 36, 0.03);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+body .signal-card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 14px 32px rgba(20, 24, 36, 0.09);
+  border-color: #cdd1dc;
+}
+body .signal-card h3 {
+  margin: 0.1rem 0 0;
+  font-size: 1.2rem;
+  font-weight: 800;
+  color: #0b0d14;
+  letter-spacing: -0.01em;
+}
+body .signal-card .signal-card-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.68rem;
+  color: #e8513f;
+  font-weight: 700;
+}
+body .signal-card .signal-card-sub {
+  color: #5c6376;
+  font-size: 0.92rem;
+}
+body .signal-card .signal-card-body {
+  color: #3a404f;
+  font-size: 0.92rem;
+  margin-top: 0.35rem;
+}
+body .signal-card .signal-card-foot {
+  margin-top: auto;
+  padding-top: 0.75rem;
+  border-top: 1px solid #eef0f5;
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  color: #5c6376;
+}
+body .signal-card .signal-tag {
+  display: inline-block;
+  background: #f1f2f7;
+  color: #3a404f;
+  padding: 0.15rem 0.6rem;
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-radius: 999px;
+}
+body .signal-card .signal-tag.is-intro       { background: #e9f6ef; color: #1d7041; }
+body .signal-card .signal-tag.is-intermediate{ background: #fdf4d6; color: #7a5512; }
+body .signal-card .signal-tag.is-advanced    { background: #fbe5e2; color: #8a2418; }
+
+/* Speaker avatar = initials circle on a brand-red disc */
+body .signal-avatar {
+  width: 56px;
+  height: 56px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #e8513f, #b33626);
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 900;
+  font-size: 1.15rem;
+  letter-spacing: 0.02em;
+  flex-shrink: 0;
+}
+
+/* ─── Schedule table ──────────────────────────────────────────────────── */
+body .schedule-day {
+  margin: 2rem auto 2.5rem;
+}
+body .schedule-day h3 {
+  text-align: center;
+  font-size: 1.55rem;
+  font-weight: 800;
+  color: #0b0d14;
+  margin: 0 0 1rem;
+  letter-spacing: -0.01em;
+}
+body table.schedule-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92rem;
+  background: #ffffff;
+  border: 1px solid #e2e4ec;
+  border-radius: 12px;
+  overflow: hidden;
+}
+body table.schedule-table thead th {
+  background: #0b0d14;
+  color: #ffffff;
+  text-align: left;
+  padding: 0.85rem 1rem;
+  font-weight: 700;
+  font-size: 0.76rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+body table.schedule-table td {
+  padding: 0.95rem 1rem;
+  border-bottom: 1px solid #e8eaf0;
+  vertical-align: top;
+}
+body table.schedule-table tr:last-child td { border-bottom: none; }
+body table.schedule-table tr:nth-child(even) td { background: #f8f9fc; }
+body table.schedule-table td.schedule-time {
+  font-weight: 700;
+  color: #0b0d14;
+  white-space: nowrap;
+  width: 110px;
+}
+body table.schedule-table td.schedule-track {
+  color: #5c6376;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+  width: 130px;
+}
+body table.schedule-table td.schedule-title strong {
+  display: block;
+  color: #0b0d14;
+  font-size: 1rem;
+  font-weight: 700;
+}
+body table.schedule-table td.schedule-title .schedule-speaker {
+  color: #5c6376;
+  font-size: 0.85rem;
+  margin-top: 0.15rem;
+}
+
+/* ─── Session + speaker + venue details ───────────────────────────────── */
+body .signal-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  max-width: 900px;
+  margin: 1.5rem auto;
+}
+body .signal-stat-grid .signal-stat {
+  background: #ffffff;
+  border: 1px solid #e2e4ec;
+  border-radius: 12px;
+  padding: 1.35rem 1.2rem;
+  text-align: center;
+}
+body .signal-stat .signal-stat-label {
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.7rem;
+  color: #5c6376;
+  font-weight: 700;
+}
+body .signal-stat .signal-stat-value {
+  font-size: 2rem;
+  font-weight: 900;
+  color: #0b0d14;
+  margin-top: 0.3rem;
+  letter-spacing: -0.015em;
+}
+
+/* ─── Sponsors tier grid ──────────────────────────────────────────────── */
+body .sponsors-tier {
+  text-align: center;
+  margin: 1.75rem 0;
+}
+body .sponsors-tier h3 {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: #5c6376;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+body .sponsor-logos {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 1.5rem;
+}
+body .sponsor-logos .sponsor {
+  background: #ffffff;
+  border: 1px solid #e2e4ec;
+  border-radius: 12px;
+  padding: 1rem 1.6rem;
+  font-weight: 800;
+  color: #0b0d14;
+  letter-spacing: -0.01em;
+  min-width: 160px;
+  text-align: center;
+}
+body .sponsor-logos .sponsor.tier-gold { font-size: 1.4rem; padding: 1.6rem 2.2rem; }
+body .sponsor-logos .sponsor.tier-silver { font-size: 1.1rem; padding: 1.2rem 1.8rem; }
+body .sponsor-logos .sponsor.tier-bronze { font-size: 0.95rem; opacity: 0.85; }
+
+/* ─── Venue map-ish block ─────────────────────────────────────────────── */
+body .signal-venue {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+  max-width: 960px;
+  margin: 1.5rem auto;
+  align-items: stretch;
+}
+body .signal-venue .signal-venue-map {
+  background: linear-gradient(135deg, #0b0d14 0%, #1c2133 60%, #2d3657 100%);
+  border-radius: 16px;
+  min-height: 340px;
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #ffffff;
+}
+body .signal-venue .signal-venue-map::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(135deg, transparent 48%, rgba(232, 81, 63, 0.12) 48%, rgba(232, 81, 63, 0.12) 52%, transparent 52%),
+    linear-gradient(45deg, transparent 48%, rgba(76, 127, 226, 0.1) 48%, rgba(76, 127, 226, 0.1) 52%, transparent 52%);
+}
+body .signal-venue .signal-venue-map .signal-venue-pin {
+  position: relative;
+  z-index: 1;
+  background: #e8513f;
+  border-radius: 999px;
+  padding: 0.6rem 1.2rem;
+  font-weight: 800;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  box-shadow: 0 6px 18px rgba(232, 81, 63, 0.4);
+}
+body .signal-venue .signal-venue-info h3 {
+  font-size: 1.4rem;
+  margin: 0 0 0.5rem;
+}
+body .signal-venue .signal-venue-info p {
+  color: #3a404f;
+  margin: 0 0 1rem;
+  line-height: 1.55;
+}
+
+/* ─── Footer ──────────────────────────────────────────────────────────── */
+body > div.component-inherited-content-area:last-of-type {
+  background: #0b0d14;
+  color: rgba(255, 255, 255, 0.72);
+  padding: 3.5rem 2rem 2rem;
+}
+body > div.component-inherited-content-area:last-of-type .ui.segment,
+body > div.component-inherited-content-area:last-of-type > div[class*="segment"] {
+  background: transparent !important;
+  padding: 0 !important;
+}
+body > div.component-inherited-content-area:last-of-type h4,
+body > div.component-inherited-content-area:last-of-type h5 {
+  color: #ffffff;
+  font-size: 0.82rem;
+  margin: 0 0 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 700;
+}
+body > div.component-inherited-content-area:last-of-type a {
+  color: rgba(255, 255, 255, 0.72);
+}
+body > div.component-inherited-content-area:last-of-type a:hover {
+  color: #ffffff;
+}
+body > div.component-inherited-content-area:last-of-type ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+body > div.component-inherited-content-area:last-of-type li {
+  padding: 0.25rem 0;
+  font-size: 0.88rem;
+}
+body > div.component-inherited-content-area:last-of-type .component-richtext > div > div {
+  display: grid !important;
+  grid-template-columns: 2fr 1fr 1fr 1fr;
+  gap: 2rem;
+  max-width: 1080px;
+  margin: 0 auto;
+}
+body > div.component-inherited-content-area:last-of-type .component-richtext > div > div > div {
+  max-width: none !important;
+  flex: none !important;
+}
+body > div.component-inherited-content-area:last-of-type hr {
+  border: none;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  margin: 2rem 0 1rem;
+  max-width: 1080px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* ─── Past-editions table ─────────────────────────────────────────────── */
+body .past-editions-table {
+  width: 100%;
+  max-width: 860px;
+  margin: 1rem auto;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+body .past-editions-table td,
+body .past-editions-table th {
+  padding: 0.85rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid #e8eaf0;
+}
+body .past-editions-table th {
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 0.76rem;
+  letter-spacing: 0.08em;
+  color: #5c6376;
+}
+body .past-editions-table strong { color: #0b0d14; }
+
+/* ─── Small utilities the pages use ───────────────────────────────────── */
+body .signal-center { text-align: center; }
+body .signal-muted { color: #5c6376; }
+body .signal-strong { font-weight: 700; color: #0b0d14; }
+
+
+/* ─── signal-framework 0.0.2 customizations ──────────────────────────
+ * Editorial indigo + red palette, serif display headlines, aurora hero. */
+:root {
+  --signal-primary:     #ff6a4a;
+  --signal-primary-dark:#c23b1d;
+  --signal-ink:         #070814;
+  --signal-indigo:      #1c1f46;
+  --signal-indigo-2:    #2a2e68;
+  --signal-cream:       #f8f5ee;
+}
+body { background: #ffffff; color: #1c1f2a; }
+body > div.component-inherited-content-area:first-of-type { background: var(--signal-ink); }
+body > div.component-inherited-content-area:first-of-type::before { color: var(--signal-primary); }
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) {
+  background: var(--signal-ink) !important;
+  padding: 9rem 2rem 8rem;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area)::before {
+  background:
+    radial-gradient(ellipse 60% 40% at 20% 30%, rgba(255, 106, 74, 0.28) 0%, transparent 60%),
+    radial-gradient(ellipse 50% 60% at 78% 68%, rgba(84, 70, 220, 0.32) 0%, transparent 55%),
+    radial-gradient(ellipse 70% 40% at 50% 100%, rgba(255, 182, 72, 0.14) 0%, transparent 60%),
+    linear-gradient(180deg, var(--signal-ink) 0%, var(--signal-indigo) 100%);
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) h1 {
+  font-family: 'Georgia', 'Libre Caslon Text', 'Baskerville', serif;
+  font-weight: 700;
+  font-size: 4.5rem;
+  letter-spacing: -0.025em;
+  line-height: 0.98;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) .component-text:first-child p {
+  color: var(--signal-primary);
+  font-family: -apple-system, 'Inter', sans-serif;
+  font-weight: 700;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) h2 {
+  font-family: 'Georgia', serif;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) .component-text:first-child p {
+  color: var(--signal-primary);
+}
+body a.ui.button,
+body .component-button-group a {
+  background: linear-gradient(135deg, var(--signal-primary) 0%, var(--signal-primary-dark) 100%);
+  box-shadow: 0 6px 18px rgba(255, 106, 74, 0.3);
+}
+body a.ui.button:hover,
+body .component-button-group a:hover {
+  background: linear-gradient(135deg, var(--signal-primary-dark) 0%, #8c220c 100%);
+}
+body > div:nth-child(4):not(.component-inherited-content-area),
+body > div:nth-child(6):not(.component-inherited-content-area),
+body > div:nth-child(8):not(.component-inherited-content-area),
+body > div:nth-child(10):not(.component-inherited-content-area),
+body > div:nth-child(12):not(.component-inherited-content-area),
+body > div:nth-child(14):not(.component-inherited-content-area) {
+  background: var(--signal-cream);
+}
+body .signal-card-eyebrow { color: var(--signal-primary); }
+body .signal-avatar { background: linear-gradient(135deg, var(--signal-primary), var(--signal-primary-dark)); }
+body a { color: var(--signal-primary); }
+body a:hover { color: var(--signal-primary-dark); }
+body table.schedule-table thead th { background: var(--signal-indigo); }
+body > div.component-inherited-content-area:last-of-type {
+  background: var(--signal-ink);
+  border-top: 3px solid var(--signal-primary);
+}
+
+/* ─── 0.0.3 · bugfix: session card height inconsistency ───────────────
+ * The sessions index had 15 cards with varying abstract length. Some
+ * cards were 180px tall, others 280px, breaking the grid rhythm.
+ * Flex-columns + min-height fix this cleanly and push the level tag
+ * + end-time to the bottom of every card. */
+body .signal-card {
+  display: flex;
+  flex-direction: column;
+  min-height: 220px;
+}
+body .signal-card .signal-card-body { flex: 1 1 auto; }
+body .signal-card .signal-card-foot { margin-top: auto; }

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.4/.content.xml
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.4/.content.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:kes="http://kestros.io/kes/1.0"
+          jcr:primaryType="kes:UiFramework"
+          jcr:title="Signal Framework 0.0.4"
+          jcr:description="Schedule table — agenda time-slot alignment + session row styling."
+          kes:uiFrameworkCode="signal-framework"
+          kes:vendorLibraries="[ui-kit/3.23.6]"
+/>

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.4/themes/default/.content.xml
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.4/themes/default/.content.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:kes="http://kestros.io/kes/1.0"
+          jcr:primaryType="kes:Theme"
+          jcr:title="Default"
+/>

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.4/themes/default/css/.content.xml
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.4/themes/default/css/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="sling:OrderedFolder"
+          include="[main.css]"
+/>

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.4/themes/default/css/main.css
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.4/themes/default/css/main.css
@@ -1,0 +1,719 @@
+body { margin: 0; }
+body .ui.menu { display: none; }
+body .ui.container { max-width: 1080px; margin: 0 auto; padding: 0 2rem; }
+/* signal-conf theme overlay on the semantic-ui default theme.
+ *
+ * Semantic UI has a strong built-in look, but Kestros components
+ * can't pass UIKit-style modifier classes through inlineVariations
+ * (it's a variation-name lookup, not raw class pass-through). So
+ * this file targets the concrete markup the signal-conf site emits
+ * and applies the finishing layer directly — dark conference hero,
+ * bold editorial typography, card grids for speakers/sessions, and
+ * a sticky schedule table.
+ */
+
+/* ─── Base typography ─────────────────────────────────────────────────── */
+body {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Roboto, Helvetica, Arial, sans-serif;
+  color: #1a1d26;
+  background: #ffffff;
+  line-height: 1.55;
+}
+a { color: #e8513f; text-decoration: none; }
+a:hover { color: #b33626; }
+h1, h2, h3, h4 { font-family: 'Inter', -apple-system, sans-serif; color: #0b0d14; }
+
+/* ─── Top navigation ──────────────────────────────────────────────────── */
+body > div.component-inherited-content-area:first-of-type {
+  background: #0b0d14;
+  padding: 1.1rem 2.5rem;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  border-bottom: 1px solid #1e2130;
+}
+body > div.component-inherited-content-area:first-of-type::before {
+  content: 'SIGNAL';
+  position: absolute;
+  left: 2.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-weight: 900;
+  letter-spacing: 0.22em;
+  font-size: 1rem;
+  color: #e8513f;
+}
+body > div.component-inherited-content-area:first-of-type .ui.menu,
+body > div.component-inherited-content-area:first-of-type .ui.menu .item {
+  background: transparent !important;
+  border: none !important;
+  padding-left: 0;
+}
+body > div.component-inherited-content-area:first-of-type a {
+  color: #c8cbd6;
+  text-decoration: none;
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  margin-left: 1.75rem;
+}
+body > div.component-inherited-content-area:first-of-type a:hover {
+  color: #ffffff;
+}
+/* Push the nav items to the right to leave room for the SIGNAL wordmark */
+body > div.component-inherited-content-area:first-of-type > .component-content-area,
+body > div.component-inherited-content-area:first-of-type > div:not(.component-inherited-content-area) {
+  text-align: right;
+}
+
+/* ─── Sections — first is hero, rest alternate ────────────────────────── */
+body > div:not(.component-inherited-content-area),
+body > div.ui.container,
+body > section,
+body > div[class*="section"] {
+  /* noop — Kestros structure/section outputs some vendor-specific class */
+}
+
+/* The Kestros structure/section HTL on semantic-ui wraps content in a
+ * <div class="ui segment ${section.inlineVariations}">. We want full-
+ * bleed hero + regular content sections. */
+body > div:not(.component-inherited-content-area) {
+  padding: 4rem 2rem;
+  background: #ffffff;
+  border: none !important;
+  box-shadow: none !important;
+  margin: 0 !important;
+  border-radius: 0 !important;
+}
+
+/* First segment after header — dark editorial hero */
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) {
+  background: #0b0d14 !important;
+  color: #ffffff;
+  padding: 8rem 2rem 7rem;
+  position: relative;
+  overflow: hidden;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area)::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 18% 28%, rgba(232, 81, 63, 0.25) 0%, transparent 45%),
+    radial-gradient(circle at 82% 72%, rgba(76, 127, 226, 0.22) 0%, transparent 45%),
+    radial-gradient(circle at 50% 100%, rgba(255, 183, 77, 0.12) 0%, transparent 55%);
+  pointer-events: none;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) > * {
+  position: relative;
+  z-index: 1;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) h1 {
+  color: #ffffff;
+  font-size: 4.25rem;
+  line-height: 0.98;
+  letter-spacing: -0.035em;
+  font-weight: 900;
+  margin: 1rem auto 1.25rem;
+  max-width: 1000px;
+  text-align: center;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) h2 {
+  color: #ffffff;
+  font-size: 2.75rem;
+  line-height: 1;
+  font-weight: 800;
+  text-align: center;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) p {
+  color: rgba(255, 255, 255, 0.78);
+  font-size: 1.2rem;
+  max-width: 720px;
+  margin: 0.75rem auto 1.5rem;
+  text-align: center;
+  line-height: 1.55;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) .component-text:first-child p {
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  font-size: 0.8rem;
+  color: #e8513f;
+  margin-bottom: 0.25rem;
+}
+
+/* Non-hero section containers */
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) {
+  background: #ffffff;
+}
+body > div:nth-child(4):not(.component-inherited-content-area),
+body > div:nth-child(6):not(.component-inherited-content-area),
+body > div:nth-child(8):not(.component-inherited-content-area),
+body > div:nth-child(10):not(.component-inherited-content-area),
+body > div:nth-child(12):not(.component-inherited-content-area),
+body > div:nth-child(14):not(.component-inherited-content-area) {
+  background: #f5f6fa;
+}
+
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) h2 {
+  font-size: 2.25rem;
+  font-weight: 800;
+  letter-spacing: -0.015em;
+  text-align: center;
+  margin: 0 auto 2rem;
+  max-width: 800px;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) .component-text:first-child p {
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.78rem;
+  color: #e8513f;
+  font-weight: 700;
+  margin-bottom: 0.4rem;
+}
+
+body > div:not(.component-inherited-content-area) > .ui.container {
+  max-width: 1080px;
+  margin: 0 auto;
+}
+
+/* ─── Button group → conference pill buttons ──────────────────────────── */
+body div[class*="uk-button-group"],
+body .component-button-group {
+  text-align: center;
+  margin-top: 1.75rem;
+}
+body a.ui.button,
+body .component-button-group a {
+  display: inline-block;
+  background: #e8513f;
+  color: #ffffff !important;
+  padding: 0.95rem 1.85rem;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  text-decoration: none;
+  margin: 0 0.4rem 0 0;
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+body a.ui.button:hover,
+body .component-button-group a:hover {
+  background: #b33626;
+  transform: translateY(-1px);
+}
+body .component-button-group a + a {
+  background: transparent;
+  color: #ffffff !important;
+  border: 1px solid rgba(255, 255, 255, 0.55);
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) .component-button-group a + a {
+  color: #0b0d14 !important;
+  border: 1px solid #0b0d14;
+}
+
+/* ─── Richtext flex/grid handling (see league-theme for rationale) ────── */
+body .component-richtext > div > div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  margin: 1.5rem auto 0;
+  justify-content: center;
+}
+body .component-richtext > div > div > table,
+body .component-richtext > div > table,
+body .component-richtext > div > ul,
+body .component-richtext > div > ol,
+body .component-richtext > div > h2,
+body .component-richtext > div > h3,
+body .component-richtext > div > h4,
+body .component-richtext > div > p {
+  display: initial;
+}
+body .component-richtext > div:has(> table),
+body .component-richtext > div:has(> ul),
+body .component-richtext > div:has(> ol),
+body .component-richtext > div:has(> h2),
+body .component-richtext > div:has(> h3) {
+  display: block;
+}
+
+/* Sponsors & schedule-day blocks need block layout (full-width tiers
+ * and day tables, not a flex row of tiers). */
+body .component-richtext > div > div:has(> .sponsors-tier),
+body .component-richtext > div > div:has(> .schedule-day),
+body .component-richtext > div > div:has(> table),
+body .component-richtext > div > div:has(> .past-editions-table) {
+  display: block;
+}
+body .component-richtext > div > div > div:not([class*="ui-grid"]):not([class*="uk-grid"]):not([class*="uk-child-width"]):not([class*="uk-flex"]):not(.sponsors-tier):not(.schedule-day):not(.signal-venue):not(.signal-stat-grid) {
+  flex: 1 1 280px;
+  max-width: 340px;
+}
+/* Full-width blocks inside a block-display wrapper */
+body .component-richtext > div > div > .sponsors-tier,
+body .component-richtext > div > div > .schedule-day,
+body .component-richtext > div > div > .signal-venue,
+body .component-richtext > div > div > .signal-stat-grid {
+  flex: none;
+  max-width: none;
+  width: 100%;
+}
+
+/* ─── Cards (speakers / sessions / sponsors) ──────────────────────────── */
+body .signal-card {
+  background: #ffffff;
+  border: 1px solid #e2e4ec;
+  border-radius: 14px;
+  padding: 1.5rem 1.4rem;
+  box-shadow: 0 1px 2px rgba(20, 24, 36, 0.03);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+body .signal-card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 14px 32px rgba(20, 24, 36, 0.09);
+  border-color: #cdd1dc;
+}
+body .signal-card h3 {
+  margin: 0.1rem 0 0;
+  font-size: 1.2rem;
+  font-weight: 800;
+  color: #0b0d14;
+  letter-spacing: -0.01em;
+}
+body .signal-card .signal-card-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.68rem;
+  color: #e8513f;
+  font-weight: 700;
+}
+body .signal-card .signal-card-sub {
+  color: #5c6376;
+  font-size: 0.92rem;
+}
+body .signal-card .signal-card-body {
+  color: #3a404f;
+  font-size: 0.92rem;
+  margin-top: 0.35rem;
+}
+body .signal-card .signal-card-foot {
+  margin-top: auto;
+  padding-top: 0.75rem;
+  border-top: 1px solid #eef0f5;
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  color: #5c6376;
+}
+body .signal-card .signal-tag {
+  display: inline-block;
+  background: #f1f2f7;
+  color: #3a404f;
+  padding: 0.15rem 0.6rem;
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-radius: 999px;
+}
+body .signal-card .signal-tag.is-intro       { background: #e9f6ef; color: #1d7041; }
+body .signal-card .signal-tag.is-intermediate{ background: #fdf4d6; color: #7a5512; }
+body .signal-card .signal-tag.is-advanced    { background: #fbe5e2; color: #8a2418; }
+
+/* Speaker avatar = initials circle on a brand-red disc */
+body .signal-avatar {
+  width: 56px;
+  height: 56px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #e8513f, #b33626);
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 900;
+  font-size: 1.15rem;
+  letter-spacing: 0.02em;
+  flex-shrink: 0;
+}
+
+/* ─── Schedule table ──────────────────────────────────────────────────── */
+body .schedule-day {
+  margin: 2rem auto 2.5rem;
+}
+body .schedule-day h3 {
+  text-align: center;
+  font-size: 1.55rem;
+  font-weight: 800;
+  color: #0b0d14;
+  margin: 0 0 1rem;
+  letter-spacing: -0.01em;
+}
+body table.schedule-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92rem;
+  background: #ffffff;
+  border: 1px solid #e2e4ec;
+  border-radius: 12px;
+  overflow: hidden;
+}
+body table.schedule-table thead th {
+  background: #0b0d14;
+  color: #ffffff;
+  text-align: left;
+  padding: 0.85rem 1rem;
+  font-weight: 700;
+  font-size: 0.76rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+body table.schedule-table td {
+  padding: 0.95rem 1rem;
+  border-bottom: 1px solid #e8eaf0;
+  vertical-align: top;
+}
+body table.schedule-table tr:last-child td { border-bottom: none; }
+body table.schedule-table tr:nth-child(even) td { background: #f8f9fc; }
+body table.schedule-table td.schedule-time {
+  font-weight: 700;
+  color: #0b0d14;
+  white-space: nowrap;
+  width: 110px;
+}
+body table.schedule-table td.schedule-track {
+  color: #5c6376;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+  width: 130px;
+}
+body table.schedule-table td.schedule-title strong {
+  display: block;
+  color: #0b0d14;
+  font-size: 1rem;
+  font-weight: 700;
+}
+body table.schedule-table td.schedule-title .schedule-speaker {
+  color: #5c6376;
+  font-size: 0.85rem;
+  margin-top: 0.15rem;
+}
+
+/* ─── Session + speaker + venue details ───────────────────────────────── */
+body .signal-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  max-width: 900px;
+  margin: 1.5rem auto;
+}
+body .signal-stat-grid .signal-stat {
+  background: #ffffff;
+  border: 1px solid #e2e4ec;
+  border-radius: 12px;
+  padding: 1.35rem 1.2rem;
+  text-align: center;
+}
+body .signal-stat .signal-stat-label {
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.7rem;
+  color: #5c6376;
+  font-weight: 700;
+}
+body .signal-stat .signal-stat-value {
+  font-size: 2rem;
+  font-weight: 900;
+  color: #0b0d14;
+  margin-top: 0.3rem;
+  letter-spacing: -0.015em;
+}
+
+/* ─── Sponsors tier grid ──────────────────────────────────────────────── */
+body .sponsors-tier {
+  text-align: center;
+  margin: 1.75rem 0;
+}
+body .sponsors-tier h3 {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: #5c6376;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+body .sponsor-logos {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 1.5rem;
+}
+body .sponsor-logos .sponsor {
+  background: #ffffff;
+  border: 1px solid #e2e4ec;
+  border-radius: 12px;
+  padding: 1rem 1.6rem;
+  font-weight: 800;
+  color: #0b0d14;
+  letter-spacing: -0.01em;
+  min-width: 160px;
+  text-align: center;
+}
+body .sponsor-logos .sponsor.tier-gold { font-size: 1.4rem; padding: 1.6rem 2.2rem; }
+body .sponsor-logos .sponsor.tier-silver { font-size: 1.1rem; padding: 1.2rem 1.8rem; }
+body .sponsor-logos .sponsor.tier-bronze { font-size: 0.95rem; opacity: 0.85; }
+
+/* ─── Venue map-ish block ─────────────────────────────────────────────── */
+body .signal-venue {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+  max-width: 960px;
+  margin: 1.5rem auto;
+  align-items: stretch;
+}
+body .signal-venue .signal-venue-map {
+  background: linear-gradient(135deg, #0b0d14 0%, #1c2133 60%, #2d3657 100%);
+  border-radius: 16px;
+  min-height: 340px;
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #ffffff;
+}
+body .signal-venue .signal-venue-map::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(135deg, transparent 48%, rgba(232, 81, 63, 0.12) 48%, rgba(232, 81, 63, 0.12) 52%, transparent 52%),
+    linear-gradient(45deg, transparent 48%, rgba(76, 127, 226, 0.1) 48%, rgba(76, 127, 226, 0.1) 52%, transparent 52%);
+}
+body .signal-venue .signal-venue-map .signal-venue-pin {
+  position: relative;
+  z-index: 1;
+  background: #e8513f;
+  border-radius: 999px;
+  padding: 0.6rem 1.2rem;
+  font-weight: 800;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  box-shadow: 0 6px 18px rgba(232, 81, 63, 0.4);
+}
+body .signal-venue .signal-venue-info h3 {
+  font-size: 1.4rem;
+  margin: 0 0 0.5rem;
+}
+body .signal-venue .signal-venue-info p {
+  color: #3a404f;
+  margin: 0 0 1rem;
+  line-height: 1.55;
+}
+
+/* ─── Footer ──────────────────────────────────────────────────────────── */
+body > div.component-inherited-content-area:last-of-type {
+  background: #0b0d14;
+  color: rgba(255, 255, 255, 0.72);
+  padding: 3.5rem 2rem 2rem;
+}
+body > div.component-inherited-content-area:last-of-type .ui.segment,
+body > div.component-inherited-content-area:last-of-type > div[class*="segment"] {
+  background: transparent !important;
+  padding: 0 !important;
+}
+body > div.component-inherited-content-area:last-of-type h4,
+body > div.component-inherited-content-area:last-of-type h5 {
+  color: #ffffff;
+  font-size: 0.82rem;
+  margin: 0 0 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 700;
+}
+body > div.component-inherited-content-area:last-of-type a {
+  color: rgba(255, 255, 255, 0.72);
+}
+body > div.component-inherited-content-area:last-of-type a:hover {
+  color: #ffffff;
+}
+body > div.component-inherited-content-area:last-of-type ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+body > div.component-inherited-content-area:last-of-type li {
+  padding: 0.25rem 0;
+  font-size: 0.88rem;
+}
+body > div.component-inherited-content-area:last-of-type .component-richtext > div > div {
+  display: grid !important;
+  grid-template-columns: 2fr 1fr 1fr 1fr;
+  gap: 2rem;
+  max-width: 1080px;
+  margin: 0 auto;
+}
+body > div.component-inherited-content-area:last-of-type .component-richtext > div > div > div {
+  max-width: none !important;
+  flex: none !important;
+}
+body > div.component-inherited-content-area:last-of-type hr {
+  border: none;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  margin: 2rem 0 1rem;
+  max-width: 1080px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* ─── Past-editions table ─────────────────────────────────────────────── */
+body .past-editions-table {
+  width: 100%;
+  max-width: 860px;
+  margin: 1rem auto;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+body .past-editions-table td,
+body .past-editions-table th {
+  padding: 0.85rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid #e8eaf0;
+}
+body .past-editions-table th {
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 0.76rem;
+  letter-spacing: 0.08em;
+  color: #5c6376;
+}
+body .past-editions-table strong { color: #0b0d14; }
+
+/* ─── Small utilities the pages use ───────────────────────────────────── */
+body .signal-center { text-align: center; }
+body .signal-muted { color: #5c6376; }
+body .signal-strong { font-weight: 700; color: #0b0d14; }
+
+
+/* ─── signal-framework 0.0.2 customizations ──────────────────────────
+ * Editorial indigo + red palette, serif display headlines, aurora hero. */
+:root {
+  --signal-primary:     #ff6a4a;
+  --signal-primary-dark:#c23b1d;
+  --signal-ink:         #070814;
+  --signal-indigo:      #1c1f46;
+  --signal-indigo-2:    #2a2e68;
+  --signal-cream:       #f8f5ee;
+}
+body { background: #ffffff; color: #1c1f2a; }
+body > div.component-inherited-content-area:first-of-type { background: var(--signal-ink); }
+body > div.component-inherited-content-area:first-of-type::before { color: var(--signal-primary); }
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) {
+  background: var(--signal-ink) !important;
+  padding: 9rem 2rem 8rem;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area)::before {
+  background:
+    radial-gradient(ellipse 60% 40% at 20% 30%, rgba(255, 106, 74, 0.28) 0%, transparent 60%),
+    radial-gradient(ellipse 50% 60% at 78% 68%, rgba(84, 70, 220, 0.32) 0%, transparent 55%),
+    radial-gradient(ellipse 70% 40% at 50% 100%, rgba(255, 182, 72, 0.14) 0%, transparent 60%),
+    linear-gradient(180deg, var(--signal-ink) 0%, var(--signal-indigo) 100%);
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) h1 {
+  font-family: 'Georgia', 'Libre Caslon Text', 'Baskerville', serif;
+  font-weight: 700;
+  font-size: 4.5rem;
+  letter-spacing: -0.025em;
+  line-height: 0.98;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) .component-text:first-child p {
+  color: var(--signal-primary);
+  font-family: -apple-system, 'Inter', sans-serif;
+  font-weight: 700;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) h2 {
+  font-family: 'Georgia', serif;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) .component-text:first-child p {
+  color: var(--signal-primary);
+}
+body a.ui.button,
+body .component-button-group a {
+  background: linear-gradient(135deg, var(--signal-primary) 0%, var(--signal-primary-dark) 100%);
+  box-shadow: 0 6px 18px rgba(255, 106, 74, 0.3);
+}
+body a.ui.button:hover,
+body .component-button-group a:hover {
+  background: linear-gradient(135deg, var(--signal-primary-dark) 0%, #8c220c 100%);
+}
+body > div:nth-child(4):not(.component-inherited-content-area),
+body > div:nth-child(6):not(.component-inherited-content-area),
+body > div:nth-child(8):not(.component-inherited-content-area),
+body > div:nth-child(10):not(.component-inherited-content-area),
+body > div:nth-child(12):not(.component-inherited-content-area),
+body > div:nth-child(14):not(.component-inherited-content-area) {
+  background: var(--signal-cream);
+}
+body .signal-card-eyebrow { color: var(--signal-primary); }
+body .signal-avatar { background: linear-gradient(135deg, var(--signal-primary), var(--signal-primary-dark)); }
+body a { color: var(--signal-primary); }
+body a:hover { color: var(--signal-primary-dark); }
+body table.schedule-table thead th { background: var(--signal-indigo); }
+body > div.component-inherited-content-area:last-of-type {
+  background: var(--signal-ink);
+  border-top: 3px solid var(--signal-primary);
+}
+
+/* ─── 0.0.3 · bugfix: session card height inconsistency ───────────────
+ * The sessions index had 15 cards with varying abstract length. Some
+ * cards were 180px tall, others 280px, breaking the grid rhythm.
+ * Flex-columns + min-height fix this cleanly and push the level tag
+ * + end-time to the bottom of every card. */
+body .signal-card {
+  display: flex;
+  flex-direction: column;
+  min-height: 220px;
+}
+body .signal-card .signal-card-body { flex: 1 1 auto; }
+body .signal-card .signal-card-foot { margin-top: auto; }
+
+/* ─── 0.0.4 · nav hover underline + card elevation ────────────────────
+ * bugfix: nav items had no hover affordance on dark nav.
+ * improvement: cards were flat — add a subtle lift on hover. */
+body > div.component-inherited-content-area:first-of-type a {
+  position: relative;
+  padding-bottom: 0.15rem;
+}
+body > div.component-inherited-content-area:first-of-type a::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -2px;
+  height: 2px;
+  background: var(--signal-primary);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.2s ease;
+}
+body > div.component-inherited-content-area:first-of-type a:hover::after {
+  transform: scaleX(1);
+}
+body .signal-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 18px 36px rgba(7, 8, 20, 0.10);
+  border-color: rgba(255, 106, 74, 0.35);
+}

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.1.0/.content.xml
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.1.0/.content.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:kes="http://kestros.io/kes/1.0"
+          jcr:primaryType="kes:UiFramework"
+          jcr:title="Signal Framework 0.1.0"
+          jcr:description="Minor — venue page layout + sponsor grid treatment."
+          kes:uiFrameworkCode="signal-framework"
+          kes:vendorLibraries="[ui-kit/3.23.6]"
+/>

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.1.0/themes/default/.content.xml
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.1.0/themes/default/.content.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:kes="http://kestros.io/kes/1.0"
+          jcr:primaryType="kes:Theme"
+          jcr:title="Default"
+/>

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.1.0/themes/default/css/.content.xml
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.1.0/themes/default/css/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="sling:OrderedFolder"
+          include="[main.css]"
+/>

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.1.0/themes/default/css/main.css
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.1.0/themes/default/css/main.css
@@ -1,0 +1,756 @@
+body { margin: 0; }
+body .ui.menu { display: none; }
+body .ui.container { max-width: 1080px; margin: 0 auto; padding: 0 2rem; }
+/* signal-conf theme overlay on the semantic-ui default theme.
+ *
+ * Semantic UI has a strong built-in look, but Kestros components
+ * can't pass UIKit-style modifier classes through inlineVariations
+ * (it's a variation-name lookup, not raw class pass-through). So
+ * this file targets the concrete markup the signal-conf site emits
+ * and applies the finishing layer directly — dark conference hero,
+ * bold editorial typography, card grids for speakers/sessions, and
+ * a sticky schedule table.
+ */
+
+/* ─── Base typography ─────────────────────────────────────────────────── */
+body {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Roboto, Helvetica, Arial, sans-serif;
+  color: #1a1d26;
+  background: #ffffff;
+  line-height: 1.55;
+}
+a { color: #e8513f; text-decoration: none; }
+a:hover { color: #b33626; }
+h1, h2, h3, h4 { font-family: 'Inter', -apple-system, sans-serif; color: #0b0d14; }
+
+/* ─── Top navigation ──────────────────────────────────────────────────── */
+body > div.component-inherited-content-area:first-of-type {
+  background: #0b0d14;
+  padding: 1.1rem 2.5rem;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  border-bottom: 1px solid #1e2130;
+}
+body > div.component-inherited-content-area:first-of-type::before {
+  content: 'SIGNAL';
+  position: absolute;
+  left: 2.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-weight: 900;
+  letter-spacing: 0.22em;
+  font-size: 1rem;
+  color: #e8513f;
+}
+body > div.component-inherited-content-area:first-of-type .ui.menu,
+body > div.component-inherited-content-area:first-of-type .ui.menu .item {
+  background: transparent !important;
+  border: none !important;
+  padding-left: 0;
+}
+body > div.component-inherited-content-area:first-of-type a {
+  color: #c8cbd6;
+  text-decoration: none;
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  margin-left: 1.75rem;
+}
+body > div.component-inherited-content-area:first-of-type a:hover {
+  color: #ffffff;
+}
+/* Push the nav items to the right to leave room for the SIGNAL wordmark */
+body > div.component-inherited-content-area:first-of-type > .component-content-area,
+body > div.component-inherited-content-area:first-of-type > div:not(.component-inherited-content-area) {
+  text-align: right;
+}
+
+/* ─── Sections — first is hero, rest alternate ────────────────────────── */
+body > div:not(.component-inherited-content-area),
+body > div.ui.container,
+body > section,
+body > div[class*="section"] {
+  /* noop — Kestros structure/section outputs some vendor-specific class */
+}
+
+/* The Kestros structure/section HTL on semantic-ui wraps content in a
+ * <div class="ui segment ${section.inlineVariations}">. We want full-
+ * bleed hero + regular content sections. */
+body > div:not(.component-inherited-content-area) {
+  padding: 4rem 2rem;
+  background: #ffffff;
+  border: none !important;
+  box-shadow: none !important;
+  margin: 0 !important;
+  border-radius: 0 !important;
+}
+
+/* First segment after header — dark editorial hero */
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) {
+  background: #0b0d14 !important;
+  color: #ffffff;
+  padding: 8rem 2rem 7rem;
+  position: relative;
+  overflow: hidden;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area)::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 18% 28%, rgba(232, 81, 63, 0.25) 0%, transparent 45%),
+    radial-gradient(circle at 82% 72%, rgba(76, 127, 226, 0.22) 0%, transparent 45%),
+    radial-gradient(circle at 50% 100%, rgba(255, 183, 77, 0.12) 0%, transparent 55%);
+  pointer-events: none;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) > * {
+  position: relative;
+  z-index: 1;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) h1 {
+  color: #ffffff;
+  font-size: 4.25rem;
+  line-height: 0.98;
+  letter-spacing: -0.035em;
+  font-weight: 900;
+  margin: 1rem auto 1.25rem;
+  max-width: 1000px;
+  text-align: center;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) h2 {
+  color: #ffffff;
+  font-size: 2.75rem;
+  line-height: 1;
+  font-weight: 800;
+  text-align: center;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) p {
+  color: rgba(255, 255, 255, 0.78);
+  font-size: 1.2rem;
+  max-width: 720px;
+  margin: 0.75rem auto 1.5rem;
+  text-align: center;
+  line-height: 1.55;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) .component-text:first-child p {
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  font-size: 0.8rem;
+  color: #e8513f;
+  margin-bottom: 0.25rem;
+}
+
+/* Non-hero section containers */
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) {
+  background: #ffffff;
+}
+body > div:nth-child(4):not(.component-inherited-content-area),
+body > div:nth-child(6):not(.component-inherited-content-area),
+body > div:nth-child(8):not(.component-inherited-content-area),
+body > div:nth-child(10):not(.component-inherited-content-area),
+body > div:nth-child(12):not(.component-inherited-content-area),
+body > div:nth-child(14):not(.component-inherited-content-area) {
+  background: #f5f6fa;
+}
+
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) h2 {
+  font-size: 2.25rem;
+  font-weight: 800;
+  letter-spacing: -0.015em;
+  text-align: center;
+  margin: 0 auto 2rem;
+  max-width: 800px;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) .component-text:first-child p {
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.78rem;
+  color: #e8513f;
+  font-weight: 700;
+  margin-bottom: 0.4rem;
+}
+
+body > div:not(.component-inherited-content-area) > .ui.container {
+  max-width: 1080px;
+  margin: 0 auto;
+}
+
+/* ─── Button group → conference pill buttons ──────────────────────────── */
+body div[class*="uk-button-group"],
+body .component-button-group {
+  text-align: center;
+  margin-top: 1.75rem;
+}
+body a.ui.button,
+body .component-button-group a {
+  display: inline-block;
+  background: #e8513f;
+  color: #ffffff !important;
+  padding: 0.95rem 1.85rem;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  text-decoration: none;
+  margin: 0 0.4rem 0 0;
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+body a.ui.button:hover,
+body .component-button-group a:hover {
+  background: #b33626;
+  transform: translateY(-1px);
+}
+body .component-button-group a + a {
+  background: transparent;
+  color: #ffffff !important;
+  border: 1px solid rgba(255, 255, 255, 0.55);
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) .component-button-group a + a {
+  color: #0b0d14 !important;
+  border: 1px solid #0b0d14;
+}
+
+/* ─── Richtext flex/grid handling (see league-theme for rationale) ────── */
+body .component-richtext > div > div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  margin: 1.5rem auto 0;
+  justify-content: center;
+}
+body .component-richtext > div > div > table,
+body .component-richtext > div > table,
+body .component-richtext > div > ul,
+body .component-richtext > div > ol,
+body .component-richtext > div > h2,
+body .component-richtext > div > h3,
+body .component-richtext > div > h4,
+body .component-richtext > div > p {
+  display: initial;
+}
+body .component-richtext > div:has(> table),
+body .component-richtext > div:has(> ul),
+body .component-richtext > div:has(> ol),
+body .component-richtext > div:has(> h2),
+body .component-richtext > div:has(> h3) {
+  display: block;
+}
+
+/* Sponsors & schedule-day blocks need block layout (full-width tiers
+ * and day tables, not a flex row of tiers). */
+body .component-richtext > div > div:has(> .sponsors-tier),
+body .component-richtext > div > div:has(> .schedule-day),
+body .component-richtext > div > div:has(> table),
+body .component-richtext > div > div:has(> .past-editions-table) {
+  display: block;
+}
+body .component-richtext > div > div > div:not([class*="ui-grid"]):not([class*="uk-grid"]):not([class*="uk-child-width"]):not([class*="uk-flex"]):not(.sponsors-tier):not(.schedule-day):not(.signal-venue):not(.signal-stat-grid) {
+  flex: 1 1 280px;
+  max-width: 340px;
+}
+/* Full-width blocks inside a block-display wrapper */
+body .component-richtext > div > div > .sponsors-tier,
+body .component-richtext > div > div > .schedule-day,
+body .component-richtext > div > div > .signal-venue,
+body .component-richtext > div > div > .signal-stat-grid {
+  flex: none;
+  max-width: none;
+  width: 100%;
+}
+
+/* ─── Cards (speakers / sessions / sponsors) ──────────────────────────── */
+body .signal-card {
+  background: #ffffff;
+  border: 1px solid #e2e4ec;
+  border-radius: 14px;
+  padding: 1.5rem 1.4rem;
+  box-shadow: 0 1px 2px rgba(20, 24, 36, 0.03);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+body .signal-card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 14px 32px rgba(20, 24, 36, 0.09);
+  border-color: #cdd1dc;
+}
+body .signal-card h3 {
+  margin: 0.1rem 0 0;
+  font-size: 1.2rem;
+  font-weight: 800;
+  color: #0b0d14;
+  letter-spacing: -0.01em;
+}
+body .signal-card .signal-card-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.68rem;
+  color: #e8513f;
+  font-weight: 700;
+}
+body .signal-card .signal-card-sub {
+  color: #5c6376;
+  font-size: 0.92rem;
+}
+body .signal-card .signal-card-body {
+  color: #3a404f;
+  font-size: 0.92rem;
+  margin-top: 0.35rem;
+}
+body .signal-card .signal-card-foot {
+  margin-top: auto;
+  padding-top: 0.75rem;
+  border-top: 1px solid #eef0f5;
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  color: #5c6376;
+}
+body .signal-card .signal-tag {
+  display: inline-block;
+  background: #f1f2f7;
+  color: #3a404f;
+  padding: 0.15rem 0.6rem;
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-radius: 999px;
+}
+body .signal-card .signal-tag.is-intro       { background: #e9f6ef; color: #1d7041; }
+body .signal-card .signal-tag.is-intermediate{ background: #fdf4d6; color: #7a5512; }
+body .signal-card .signal-tag.is-advanced    { background: #fbe5e2; color: #8a2418; }
+
+/* Speaker avatar = initials circle on a brand-red disc */
+body .signal-avatar {
+  width: 56px;
+  height: 56px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #e8513f, #b33626);
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 900;
+  font-size: 1.15rem;
+  letter-spacing: 0.02em;
+  flex-shrink: 0;
+}
+
+/* ─── Schedule table ──────────────────────────────────────────────────── */
+body .schedule-day {
+  margin: 2rem auto 2.5rem;
+}
+body .schedule-day h3 {
+  text-align: center;
+  font-size: 1.55rem;
+  font-weight: 800;
+  color: #0b0d14;
+  margin: 0 0 1rem;
+  letter-spacing: -0.01em;
+}
+body table.schedule-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92rem;
+  background: #ffffff;
+  border: 1px solid #e2e4ec;
+  border-radius: 12px;
+  overflow: hidden;
+}
+body table.schedule-table thead th {
+  background: #0b0d14;
+  color: #ffffff;
+  text-align: left;
+  padding: 0.85rem 1rem;
+  font-weight: 700;
+  font-size: 0.76rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+body table.schedule-table td {
+  padding: 0.95rem 1rem;
+  border-bottom: 1px solid #e8eaf0;
+  vertical-align: top;
+}
+body table.schedule-table tr:last-child td { border-bottom: none; }
+body table.schedule-table tr:nth-child(even) td { background: #f8f9fc; }
+body table.schedule-table td.schedule-time {
+  font-weight: 700;
+  color: #0b0d14;
+  white-space: nowrap;
+  width: 110px;
+}
+body table.schedule-table td.schedule-track {
+  color: #5c6376;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+  width: 130px;
+}
+body table.schedule-table td.schedule-title strong {
+  display: block;
+  color: #0b0d14;
+  font-size: 1rem;
+  font-weight: 700;
+}
+body table.schedule-table td.schedule-title .schedule-speaker {
+  color: #5c6376;
+  font-size: 0.85rem;
+  margin-top: 0.15rem;
+}
+
+/* ─── Session + speaker + venue details ───────────────────────────────── */
+body .signal-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  max-width: 900px;
+  margin: 1.5rem auto;
+}
+body .signal-stat-grid .signal-stat {
+  background: #ffffff;
+  border: 1px solid #e2e4ec;
+  border-radius: 12px;
+  padding: 1.35rem 1.2rem;
+  text-align: center;
+}
+body .signal-stat .signal-stat-label {
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.7rem;
+  color: #5c6376;
+  font-weight: 700;
+}
+body .signal-stat .signal-stat-value {
+  font-size: 2rem;
+  font-weight: 900;
+  color: #0b0d14;
+  margin-top: 0.3rem;
+  letter-spacing: -0.015em;
+}
+
+/* ─── Sponsors tier grid ──────────────────────────────────────────────── */
+body .sponsors-tier {
+  text-align: center;
+  margin: 1.75rem 0;
+}
+body .sponsors-tier h3 {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: #5c6376;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+body .sponsor-logos {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 1.5rem;
+}
+body .sponsor-logos .sponsor {
+  background: #ffffff;
+  border: 1px solid #e2e4ec;
+  border-radius: 12px;
+  padding: 1rem 1.6rem;
+  font-weight: 800;
+  color: #0b0d14;
+  letter-spacing: -0.01em;
+  min-width: 160px;
+  text-align: center;
+}
+body .sponsor-logos .sponsor.tier-gold { font-size: 1.4rem; padding: 1.6rem 2.2rem; }
+body .sponsor-logos .sponsor.tier-silver { font-size: 1.1rem; padding: 1.2rem 1.8rem; }
+body .sponsor-logos .sponsor.tier-bronze { font-size: 0.95rem; opacity: 0.85; }
+
+/* ─── Venue map-ish block ─────────────────────────────────────────────── */
+body .signal-venue {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+  max-width: 960px;
+  margin: 1.5rem auto;
+  align-items: stretch;
+}
+body .signal-venue .signal-venue-map {
+  background: linear-gradient(135deg, #0b0d14 0%, #1c2133 60%, #2d3657 100%);
+  border-radius: 16px;
+  min-height: 340px;
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #ffffff;
+}
+body .signal-venue .signal-venue-map::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(135deg, transparent 48%, rgba(232, 81, 63, 0.12) 48%, rgba(232, 81, 63, 0.12) 52%, transparent 52%),
+    linear-gradient(45deg, transparent 48%, rgba(76, 127, 226, 0.1) 48%, rgba(76, 127, 226, 0.1) 52%, transparent 52%);
+}
+body .signal-venue .signal-venue-map .signal-venue-pin {
+  position: relative;
+  z-index: 1;
+  background: #e8513f;
+  border-radius: 999px;
+  padding: 0.6rem 1.2rem;
+  font-weight: 800;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  box-shadow: 0 6px 18px rgba(232, 81, 63, 0.4);
+}
+body .signal-venue .signal-venue-info h3 {
+  font-size: 1.4rem;
+  margin: 0 0 0.5rem;
+}
+body .signal-venue .signal-venue-info p {
+  color: #3a404f;
+  margin: 0 0 1rem;
+  line-height: 1.55;
+}
+
+/* ─── Footer ──────────────────────────────────────────────────────────── */
+body > div.component-inherited-content-area:last-of-type {
+  background: #0b0d14;
+  color: rgba(255, 255, 255, 0.72);
+  padding: 3.5rem 2rem 2rem;
+}
+body > div.component-inherited-content-area:last-of-type .ui.segment,
+body > div.component-inherited-content-area:last-of-type > div[class*="segment"] {
+  background: transparent !important;
+  padding: 0 !important;
+}
+body > div.component-inherited-content-area:last-of-type h4,
+body > div.component-inherited-content-area:last-of-type h5 {
+  color: #ffffff;
+  font-size: 0.82rem;
+  margin: 0 0 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 700;
+}
+body > div.component-inherited-content-area:last-of-type a {
+  color: rgba(255, 255, 255, 0.72);
+}
+body > div.component-inherited-content-area:last-of-type a:hover {
+  color: #ffffff;
+}
+body > div.component-inherited-content-area:last-of-type ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+body > div.component-inherited-content-area:last-of-type li {
+  padding: 0.25rem 0;
+  font-size: 0.88rem;
+}
+body > div.component-inherited-content-area:last-of-type .component-richtext > div > div {
+  display: grid !important;
+  grid-template-columns: 2fr 1fr 1fr 1fr;
+  gap: 2rem;
+  max-width: 1080px;
+  margin: 0 auto;
+}
+body > div.component-inherited-content-area:last-of-type .component-richtext > div > div > div {
+  max-width: none !important;
+  flex: none !important;
+}
+body > div.component-inherited-content-area:last-of-type hr {
+  border: none;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  margin: 2rem 0 1rem;
+  max-width: 1080px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* ─── Past-editions table ─────────────────────────────────────────────── */
+body .past-editions-table {
+  width: 100%;
+  max-width: 860px;
+  margin: 1rem auto;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+body .past-editions-table td,
+body .past-editions-table th {
+  padding: 0.85rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid #e8eaf0;
+}
+body .past-editions-table th {
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 0.76rem;
+  letter-spacing: 0.08em;
+  color: #5c6376;
+}
+body .past-editions-table strong { color: #0b0d14; }
+
+/* ─── Small utilities the pages use ───────────────────────────────────── */
+body .signal-center { text-align: center; }
+body .signal-muted { color: #5c6376; }
+body .signal-strong { font-weight: 700; color: #0b0d14; }
+
+
+/* ─── signal-framework 0.0.2 customizations ──────────────────────────
+ * Editorial indigo + red palette, serif display headlines, aurora hero. */
+:root {
+  --signal-primary:     #ff6a4a;
+  --signal-primary-dark:#c23b1d;
+  --signal-ink:         #070814;
+  --signal-indigo:      #1c1f46;
+  --signal-indigo-2:    #2a2e68;
+  --signal-cream:       #f8f5ee;
+}
+body { background: #ffffff; color: #1c1f2a; }
+body > div.component-inherited-content-area:first-of-type { background: var(--signal-ink); }
+body > div.component-inherited-content-area:first-of-type::before { color: var(--signal-primary); }
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) {
+  background: var(--signal-ink) !important;
+  padding: 9rem 2rem 8rem;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area)::before {
+  background:
+    radial-gradient(ellipse 60% 40% at 20% 30%, rgba(255, 106, 74, 0.28) 0%, transparent 60%),
+    radial-gradient(ellipse 50% 60% at 78% 68%, rgba(84, 70, 220, 0.32) 0%, transparent 55%),
+    radial-gradient(ellipse 70% 40% at 50% 100%, rgba(255, 182, 72, 0.14) 0%, transparent 60%),
+    linear-gradient(180deg, var(--signal-ink) 0%, var(--signal-indigo) 100%);
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) h1 {
+  font-family: 'Georgia', 'Libre Caslon Text', 'Baskerville', serif;
+  font-weight: 700;
+  font-size: 4.5rem;
+  letter-spacing: -0.025em;
+  line-height: 0.98;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) .component-text:first-child p {
+  color: var(--signal-primary);
+  font-family: -apple-system, 'Inter', sans-serif;
+  font-weight: 700;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) h2 {
+  font-family: 'Georgia', serif;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) .component-text:first-child p {
+  color: var(--signal-primary);
+}
+body a.ui.button,
+body .component-button-group a {
+  background: linear-gradient(135deg, var(--signal-primary) 0%, var(--signal-primary-dark) 100%);
+  box-shadow: 0 6px 18px rgba(255, 106, 74, 0.3);
+}
+body a.ui.button:hover,
+body .component-button-group a:hover {
+  background: linear-gradient(135deg, var(--signal-primary-dark) 0%, #8c220c 100%);
+}
+body > div:nth-child(4):not(.component-inherited-content-area),
+body > div:nth-child(6):not(.component-inherited-content-area),
+body > div:nth-child(8):not(.component-inherited-content-area),
+body > div:nth-child(10):not(.component-inherited-content-area),
+body > div:nth-child(12):not(.component-inherited-content-area),
+body > div:nth-child(14):not(.component-inherited-content-area) {
+  background: var(--signal-cream);
+}
+body .signal-card-eyebrow { color: var(--signal-primary); }
+body .signal-avatar { background: linear-gradient(135deg, var(--signal-primary), var(--signal-primary-dark)); }
+body a { color: var(--signal-primary); }
+body a:hover { color: var(--signal-primary-dark); }
+body table.schedule-table thead th { background: var(--signal-indigo); }
+body > div.component-inherited-content-area:last-of-type {
+  background: var(--signal-ink);
+  border-top: 3px solid var(--signal-primary);
+}
+
+/* ─── 0.0.3 · bugfix: session card height inconsistency ───────────────
+ * The sessions index had 15 cards with varying abstract length. Some
+ * cards were 180px tall, others 280px, breaking the grid rhythm.
+ * Flex-columns + min-height fix this cleanly and push the level tag
+ * + end-time to the bottom of every card. */
+body .signal-card {
+  display: flex;
+  flex-direction: column;
+  min-height: 220px;
+}
+body .signal-card .signal-card-body { flex: 1 1 auto; }
+body .signal-card .signal-card-foot { margin-top: auto; }
+
+/* ─── 0.0.4 · nav hover underline + card elevation ────────────────────
+ * bugfix: nav items had no hover affordance on dark nav.
+ * improvement: cards were flat — add a subtle lift on hover. */
+body > div.component-inherited-content-area:first-of-type a {
+  position: relative;
+  padding-bottom: 0.15rem;
+}
+body > div.component-inherited-content-area:first-of-type a::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -2px;
+  height: 2px;
+  background: var(--signal-primary);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.2s ease;
+}
+body > div.component-inherited-content-area:first-of-type a:hover::after {
+  transform: scaleX(1);
+}
+body .signal-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 18px 36px rgba(7, 8, 20, 0.10);
+  border-color: rgba(255, 106, 74, 0.35);
+}
+
+/* ─── 0.1.0 · schedule legend + border accents ────────────────────────
+ * Minor release. Adds a small legend row above each day's schedule
+ * table explaining the level tags. Also introduces a left-accent
+ * border on hovered schedule rows in brand red. */
+body .schedule-day {
+  position: relative;
+}
+body .schedule-day h3 + table.schedule-table {
+  margin-top: 1.25rem;
+}
+body .schedule-day h3::after {
+  content: 'Intro · Intermediate · Advanced · levels are a rough guide';
+  display: block;
+  font-size: 0.72rem;
+  font-weight: 500;
+  font-family: 'Inter', sans-serif;
+  color: var(--signal-indigo-2);
+  letter-spacing: 0.05em;
+  margin-top: 0.35rem;
+  text-transform: none;
+}
+body table.schedule-table tbody tr {
+  position: relative;
+  transition: background 0.15s ease, box-shadow 0.15s ease;
+}
+body table.schedule-table tbody tr:hover {
+  background: rgba(255, 106, 74, 0.05);
+  box-shadow: inset 3px 0 0 0 var(--signal-primary);
+}
+
+/* Speaker card avatar bounce on card hover */
+body .signal-card:hover .signal-avatar {
+  transform: scale(1.06) rotate(-3deg);
+  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+body .signal-avatar { transition: transform 0.25s ease; }

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/1.0.0/.content.xml
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/1.0.0/.content.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:kes="http://kestros.io/kes/1.0"
+          jcr:primaryType="kes:UiFramework"
+          jcr:title="Signal Framework 1.0.0"
+          jcr:description="Major — interactive schedule filters + speaker bio expand/collapse styling."
+          kes:uiFrameworkCode="signal-framework"
+          kes:vendorLibraries="[ui-kit/3.23.6]"
+/>

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/1.0.0/themes/default/.content.xml
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/1.0.0/themes/default/.content.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:kes="http://kestros.io/kes/1.0"
+          jcr:primaryType="kes:Theme"
+          jcr:title="Default"
+/>

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/1.0.0/themes/default/css/.content.xml
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/1.0.0/themes/default/css/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="sling:OrderedFolder"
+          include="[main.css]"
+/>

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/1.0.0/themes/default/css/main.css
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/1.0.0/themes/default/css/main.css
@@ -1,0 +1,853 @@
+body { margin: 0; }
+body .ui.menu { display: none; }
+body .ui.container { max-width: 1080px; margin: 0 auto; padding: 0 2rem; }
+/* signal-conf theme overlay on the semantic-ui default theme.
+ *
+ * Semantic UI has a strong built-in look, but Kestros components
+ * can't pass UIKit-style modifier classes through inlineVariations
+ * (it's a variation-name lookup, not raw class pass-through). So
+ * this file targets the concrete markup the signal-conf site emits
+ * and applies the finishing layer directly — dark conference hero,
+ * bold editorial typography, card grids for speakers/sessions, and
+ * a sticky schedule table.
+ */
+
+/* ─── Base typography ─────────────────────────────────────────────────── */
+body {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Roboto, Helvetica, Arial, sans-serif;
+  color: #1a1d26;
+  background: #ffffff;
+  line-height: 1.55;
+}
+a { color: #e8513f; text-decoration: none; }
+a:hover { color: #b33626; }
+h1, h2, h3, h4 { font-family: 'Inter', -apple-system, sans-serif; color: #0b0d14; }
+
+/* ─── Top navigation ──────────────────────────────────────────────────── */
+body > div.component-inherited-content-area:first-of-type {
+  background: #0b0d14;
+  padding: 1.1rem 2.5rem;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  border-bottom: 1px solid #1e2130;
+}
+body > div.component-inherited-content-area:first-of-type::before {
+  content: 'SIGNAL';
+  position: absolute;
+  left: 2.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-weight: 900;
+  letter-spacing: 0.22em;
+  font-size: 1rem;
+  color: #e8513f;
+}
+body > div.component-inherited-content-area:first-of-type .ui.menu,
+body > div.component-inherited-content-area:first-of-type .ui.menu .item {
+  background: transparent !important;
+  border: none !important;
+  padding-left: 0;
+}
+body > div.component-inherited-content-area:first-of-type a {
+  color: #c8cbd6;
+  text-decoration: none;
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  margin-left: 1.75rem;
+}
+body > div.component-inherited-content-area:first-of-type a:hover {
+  color: #ffffff;
+}
+/* Push the nav items to the right to leave room for the SIGNAL wordmark */
+body > div.component-inherited-content-area:first-of-type > .component-content-area,
+body > div.component-inherited-content-area:first-of-type > div:not(.component-inherited-content-area) {
+  text-align: right;
+}
+
+/* ─── Sections — first is hero, rest alternate ────────────────────────── */
+body > div:not(.component-inherited-content-area),
+body > div.ui.container,
+body > section,
+body > div[class*="section"] {
+  /* noop — Kestros structure/section outputs some vendor-specific class */
+}
+
+/* The Kestros structure/section HTL on semantic-ui wraps content in a
+ * <div class="ui segment ${section.inlineVariations}">. We want full-
+ * bleed hero + regular content sections. */
+body > div:not(.component-inherited-content-area) {
+  padding: 4rem 2rem;
+  background: #ffffff;
+  border: none !important;
+  box-shadow: none !important;
+  margin: 0 !important;
+  border-radius: 0 !important;
+}
+
+/* First segment after header — dark editorial hero */
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) {
+  background: #0b0d14 !important;
+  color: #ffffff;
+  padding: 8rem 2rem 7rem;
+  position: relative;
+  overflow: hidden;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area)::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 18% 28%, rgba(232, 81, 63, 0.25) 0%, transparent 45%),
+    radial-gradient(circle at 82% 72%, rgba(76, 127, 226, 0.22) 0%, transparent 45%),
+    radial-gradient(circle at 50% 100%, rgba(255, 183, 77, 0.12) 0%, transparent 55%);
+  pointer-events: none;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) > * {
+  position: relative;
+  z-index: 1;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) h1 {
+  color: #ffffff;
+  font-size: 4.25rem;
+  line-height: 0.98;
+  letter-spacing: -0.035em;
+  font-weight: 900;
+  margin: 1rem auto 1.25rem;
+  max-width: 1000px;
+  text-align: center;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) h2 {
+  color: #ffffff;
+  font-size: 2.75rem;
+  line-height: 1;
+  font-weight: 800;
+  text-align: center;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) p {
+  color: rgba(255, 255, 255, 0.78);
+  font-size: 1.2rem;
+  max-width: 720px;
+  margin: 0.75rem auto 1.5rem;
+  text-align: center;
+  line-height: 1.55;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) .component-text:first-child p {
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  font-size: 0.8rem;
+  color: #e8513f;
+  margin-bottom: 0.25rem;
+}
+
+/* Non-hero section containers */
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) {
+  background: #ffffff;
+}
+body > div:nth-child(4):not(.component-inherited-content-area),
+body > div:nth-child(6):not(.component-inherited-content-area),
+body > div:nth-child(8):not(.component-inherited-content-area),
+body > div:nth-child(10):not(.component-inherited-content-area),
+body > div:nth-child(12):not(.component-inherited-content-area),
+body > div:nth-child(14):not(.component-inherited-content-area) {
+  background: #f5f6fa;
+}
+
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) h2 {
+  font-size: 2.25rem;
+  font-weight: 800;
+  letter-spacing: -0.015em;
+  text-align: center;
+  margin: 0 auto 2rem;
+  max-width: 800px;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) .component-text:first-child p {
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.78rem;
+  color: #e8513f;
+  font-weight: 700;
+  margin-bottom: 0.4rem;
+}
+
+body > div:not(.component-inherited-content-area) > .ui.container {
+  max-width: 1080px;
+  margin: 0 auto;
+}
+
+/* ─── Button group → conference pill buttons ──────────────────────────── */
+body div[class*="uk-button-group"],
+body .component-button-group {
+  text-align: center;
+  margin-top: 1.75rem;
+}
+body a.ui.button,
+body .component-button-group a {
+  display: inline-block;
+  background: #e8513f;
+  color: #ffffff !important;
+  padding: 0.95rem 1.85rem;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  text-decoration: none;
+  margin: 0 0.4rem 0 0;
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+body a.ui.button:hover,
+body .component-button-group a:hover {
+  background: #b33626;
+  transform: translateY(-1px);
+}
+body .component-button-group a + a {
+  background: transparent;
+  color: #ffffff !important;
+  border: 1px solid rgba(255, 255, 255, 0.55);
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) .component-button-group a + a {
+  color: #0b0d14 !important;
+  border: 1px solid #0b0d14;
+}
+
+/* ─── Richtext flex/grid handling (see league-theme for rationale) ────── */
+body .component-richtext > div > div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  margin: 1.5rem auto 0;
+  justify-content: center;
+}
+body .component-richtext > div > div > table,
+body .component-richtext > div > table,
+body .component-richtext > div > ul,
+body .component-richtext > div > ol,
+body .component-richtext > div > h2,
+body .component-richtext > div > h3,
+body .component-richtext > div > h4,
+body .component-richtext > div > p {
+  display: initial;
+}
+body .component-richtext > div:has(> table),
+body .component-richtext > div:has(> ul),
+body .component-richtext > div:has(> ol),
+body .component-richtext > div:has(> h2),
+body .component-richtext > div:has(> h3) {
+  display: block;
+}
+
+/* Sponsors & schedule-day blocks need block layout (full-width tiers
+ * and day tables, not a flex row of tiers). */
+body .component-richtext > div > div:has(> .sponsors-tier),
+body .component-richtext > div > div:has(> .schedule-day),
+body .component-richtext > div > div:has(> table),
+body .component-richtext > div > div:has(> .past-editions-table) {
+  display: block;
+}
+body .component-richtext > div > div > div:not([class*="ui-grid"]):not([class*="uk-grid"]):not([class*="uk-child-width"]):not([class*="uk-flex"]):not(.sponsors-tier):not(.schedule-day):not(.signal-venue):not(.signal-stat-grid) {
+  flex: 1 1 280px;
+  max-width: 340px;
+}
+/* Full-width blocks inside a block-display wrapper */
+body .component-richtext > div > div > .sponsors-tier,
+body .component-richtext > div > div > .schedule-day,
+body .component-richtext > div > div > .signal-venue,
+body .component-richtext > div > div > .signal-stat-grid {
+  flex: none;
+  max-width: none;
+  width: 100%;
+}
+
+/* ─── Cards (speakers / sessions / sponsors) ──────────────────────────── */
+body .signal-card {
+  background: #ffffff;
+  border: 1px solid #e2e4ec;
+  border-radius: 14px;
+  padding: 1.5rem 1.4rem;
+  box-shadow: 0 1px 2px rgba(20, 24, 36, 0.03);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+body .signal-card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 14px 32px rgba(20, 24, 36, 0.09);
+  border-color: #cdd1dc;
+}
+body .signal-card h3 {
+  margin: 0.1rem 0 0;
+  font-size: 1.2rem;
+  font-weight: 800;
+  color: #0b0d14;
+  letter-spacing: -0.01em;
+}
+body .signal-card .signal-card-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.68rem;
+  color: #e8513f;
+  font-weight: 700;
+}
+body .signal-card .signal-card-sub {
+  color: #5c6376;
+  font-size: 0.92rem;
+}
+body .signal-card .signal-card-body {
+  color: #3a404f;
+  font-size: 0.92rem;
+  margin-top: 0.35rem;
+}
+body .signal-card .signal-card-foot {
+  margin-top: auto;
+  padding-top: 0.75rem;
+  border-top: 1px solid #eef0f5;
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  color: #5c6376;
+}
+body .signal-card .signal-tag {
+  display: inline-block;
+  background: #f1f2f7;
+  color: #3a404f;
+  padding: 0.15rem 0.6rem;
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-radius: 999px;
+}
+body .signal-card .signal-tag.is-intro       { background: #e9f6ef; color: #1d7041; }
+body .signal-card .signal-tag.is-intermediate{ background: #fdf4d6; color: #7a5512; }
+body .signal-card .signal-tag.is-advanced    { background: #fbe5e2; color: #8a2418; }
+
+/* Speaker avatar = initials circle on a brand-red disc */
+body .signal-avatar {
+  width: 56px;
+  height: 56px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #e8513f, #b33626);
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 900;
+  font-size: 1.15rem;
+  letter-spacing: 0.02em;
+  flex-shrink: 0;
+}
+
+/* ─── Schedule table ──────────────────────────────────────────────────── */
+body .schedule-day {
+  margin: 2rem auto 2.5rem;
+}
+body .schedule-day h3 {
+  text-align: center;
+  font-size: 1.55rem;
+  font-weight: 800;
+  color: #0b0d14;
+  margin: 0 0 1rem;
+  letter-spacing: -0.01em;
+}
+body table.schedule-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92rem;
+  background: #ffffff;
+  border: 1px solid #e2e4ec;
+  border-radius: 12px;
+  overflow: hidden;
+}
+body table.schedule-table thead th {
+  background: #0b0d14;
+  color: #ffffff;
+  text-align: left;
+  padding: 0.85rem 1rem;
+  font-weight: 700;
+  font-size: 0.76rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+body table.schedule-table td {
+  padding: 0.95rem 1rem;
+  border-bottom: 1px solid #e8eaf0;
+  vertical-align: top;
+}
+body table.schedule-table tr:last-child td { border-bottom: none; }
+body table.schedule-table tr:nth-child(even) td { background: #f8f9fc; }
+body table.schedule-table td.schedule-time {
+  font-weight: 700;
+  color: #0b0d14;
+  white-space: nowrap;
+  width: 110px;
+}
+body table.schedule-table td.schedule-track {
+  color: #5c6376;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+  width: 130px;
+}
+body table.schedule-table td.schedule-title strong {
+  display: block;
+  color: #0b0d14;
+  font-size: 1rem;
+  font-weight: 700;
+}
+body table.schedule-table td.schedule-title .schedule-speaker {
+  color: #5c6376;
+  font-size: 0.85rem;
+  margin-top: 0.15rem;
+}
+
+/* ─── Session + speaker + venue details ───────────────────────────────── */
+body .signal-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  max-width: 900px;
+  margin: 1.5rem auto;
+}
+body .signal-stat-grid .signal-stat {
+  background: #ffffff;
+  border: 1px solid #e2e4ec;
+  border-radius: 12px;
+  padding: 1.35rem 1.2rem;
+  text-align: center;
+}
+body .signal-stat .signal-stat-label {
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.7rem;
+  color: #5c6376;
+  font-weight: 700;
+}
+body .signal-stat .signal-stat-value {
+  font-size: 2rem;
+  font-weight: 900;
+  color: #0b0d14;
+  margin-top: 0.3rem;
+  letter-spacing: -0.015em;
+}
+
+/* ─── Sponsors tier grid ──────────────────────────────────────────────── */
+body .sponsors-tier {
+  text-align: center;
+  margin: 1.75rem 0;
+}
+body .sponsors-tier h3 {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: #5c6376;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+body .sponsor-logos {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 1.5rem;
+}
+body .sponsor-logos .sponsor {
+  background: #ffffff;
+  border: 1px solid #e2e4ec;
+  border-radius: 12px;
+  padding: 1rem 1.6rem;
+  font-weight: 800;
+  color: #0b0d14;
+  letter-spacing: -0.01em;
+  min-width: 160px;
+  text-align: center;
+}
+body .sponsor-logos .sponsor.tier-gold { font-size: 1.4rem; padding: 1.6rem 2.2rem; }
+body .sponsor-logos .sponsor.tier-silver { font-size: 1.1rem; padding: 1.2rem 1.8rem; }
+body .sponsor-logos .sponsor.tier-bronze { font-size: 0.95rem; opacity: 0.85; }
+
+/* ─── Venue map-ish block ─────────────────────────────────────────────── */
+body .signal-venue {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+  max-width: 960px;
+  margin: 1.5rem auto;
+  align-items: stretch;
+}
+body .signal-venue .signal-venue-map {
+  background: linear-gradient(135deg, #0b0d14 0%, #1c2133 60%, #2d3657 100%);
+  border-radius: 16px;
+  min-height: 340px;
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #ffffff;
+}
+body .signal-venue .signal-venue-map::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(135deg, transparent 48%, rgba(232, 81, 63, 0.12) 48%, rgba(232, 81, 63, 0.12) 52%, transparent 52%),
+    linear-gradient(45deg, transparent 48%, rgba(76, 127, 226, 0.1) 48%, rgba(76, 127, 226, 0.1) 52%, transparent 52%);
+}
+body .signal-venue .signal-venue-map .signal-venue-pin {
+  position: relative;
+  z-index: 1;
+  background: #e8513f;
+  border-radius: 999px;
+  padding: 0.6rem 1.2rem;
+  font-weight: 800;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  box-shadow: 0 6px 18px rgba(232, 81, 63, 0.4);
+}
+body .signal-venue .signal-venue-info h3 {
+  font-size: 1.4rem;
+  margin: 0 0 0.5rem;
+}
+body .signal-venue .signal-venue-info p {
+  color: #3a404f;
+  margin: 0 0 1rem;
+  line-height: 1.55;
+}
+
+/* ─── Footer ──────────────────────────────────────────────────────────── */
+body > div.component-inherited-content-area:last-of-type {
+  background: #0b0d14;
+  color: rgba(255, 255, 255, 0.72);
+  padding: 3.5rem 2rem 2rem;
+}
+body > div.component-inherited-content-area:last-of-type .ui.segment,
+body > div.component-inherited-content-area:last-of-type > div[class*="segment"] {
+  background: transparent !important;
+  padding: 0 !important;
+}
+body > div.component-inherited-content-area:last-of-type h4,
+body > div.component-inherited-content-area:last-of-type h5 {
+  color: #ffffff;
+  font-size: 0.82rem;
+  margin: 0 0 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 700;
+}
+body > div.component-inherited-content-area:last-of-type a {
+  color: rgba(255, 255, 255, 0.72);
+}
+body > div.component-inherited-content-area:last-of-type a:hover {
+  color: #ffffff;
+}
+body > div.component-inherited-content-area:last-of-type ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+body > div.component-inherited-content-area:last-of-type li {
+  padding: 0.25rem 0;
+  font-size: 0.88rem;
+}
+body > div.component-inherited-content-area:last-of-type .component-richtext > div > div {
+  display: grid !important;
+  grid-template-columns: 2fr 1fr 1fr 1fr;
+  gap: 2rem;
+  max-width: 1080px;
+  margin: 0 auto;
+}
+body > div.component-inherited-content-area:last-of-type .component-richtext > div > div > div {
+  max-width: none !important;
+  flex: none !important;
+}
+body > div.component-inherited-content-area:last-of-type hr {
+  border: none;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  margin: 2rem 0 1rem;
+  max-width: 1080px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* ─── Past-editions table ─────────────────────────────────────────────── */
+body .past-editions-table {
+  width: 100%;
+  max-width: 860px;
+  margin: 1rem auto;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+body .past-editions-table td,
+body .past-editions-table th {
+  padding: 0.85rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid #e8eaf0;
+}
+body .past-editions-table th {
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 0.76rem;
+  letter-spacing: 0.08em;
+  color: #5c6376;
+}
+body .past-editions-table strong { color: #0b0d14; }
+
+/* ─── Small utilities the pages use ───────────────────────────────────── */
+body .signal-center { text-align: center; }
+body .signal-muted { color: #5c6376; }
+body .signal-strong { font-weight: 700; color: #0b0d14; }
+
+
+/* ─── signal-framework 0.0.2 customizations ──────────────────────────
+ * Editorial indigo + red palette, serif display headlines, aurora hero. */
+:root {
+  --signal-primary:     #ff6a4a;
+  --signal-primary-dark:#c23b1d;
+  --signal-ink:         #070814;
+  --signal-indigo:      #1c1f46;
+  --signal-indigo-2:    #2a2e68;
+  --signal-cream:       #f8f5ee;
+}
+body { background: #ffffff; color: #1c1f2a; }
+body > div.component-inherited-content-area:first-of-type { background: var(--signal-ink); }
+body > div.component-inherited-content-area:first-of-type::before { color: var(--signal-primary); }
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) {
+  background: var(--signal-ink) !important;
+  padding: 9rem 2rem 8rem;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area)::before {
+  background:
+    radial-gradient(ellipse 60% 40% at 20% 30%, rgba(255, 106, 74, 0.28) 0%, transparent 60%),
+    radial-gradient(ellipse 50% 60% at 78% 68%, rgba(84, 70, 220, 0.32) 0%, transparent 55%),
+    radial-gradient(ellipse 70% 40% at 50% 100%, rgba(255, 182, 72, 0.14) 0%, transparent 60%),
+    linear-gradient(180deg, var(--signal-ink) 0%, var(--signal-indigo) 100%);
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) h1 {
+  font-family: 'Georgia', 'Libre Caslon Text', 'Baskerville', serif;
+  font-weight: 700;
+  font-size: 4.5rem;
+  letter-spacing: -0.025em;
+  line-height: 0.98;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) .component-text:first-child p {
+  color: var(--signal-primary);
+  font-family: -apple-system, 'Inter', sans-serif;
+  font-weight: 700;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) h2 {
+  font-family: 'Georgia', serif;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) .component-text:first-child p {
+  color: var(--signal-primary);
+}
+body a.ui.button,
+body .component-button-group a {
+  background: linear-gradient(135deg, var(--signal-primary) 0%, var(--signal-primary-dark) 100%);
+  box-shadow: 0 6px 18px rgba(255, 106, 74, 0.3);
+}
+body a.ui.button:hover,
+body .component-button-group a:hover {
+  background: linear-gradient(135deg, var(--signal-primary-dark) 0%, #8c220c 100%);
+}
+body > div:nth-child(4):not(.component-inherited-content-area),
+body > div:nth-child(6):not(.component-inherited-content-area),
+body > div:nth-child(8):not(.component-inherited-content-area),
+body > div:nth-child(10):not(.component-inherited-content-area),
+body > div:nth-child(12):not(.component-inherited-content-area),
+body > div:nth-child(14):not(.component-inherited-content-area) {
+  background: var(--signal-cream);
+}
+body .signal-card-eyebrow { color: var(--signal-primary); }
+body .signal-avatar { background: linear-gradient(135deg, var(--signal-primary), var(--signal-primary-dark)); }
+body a { color: var(--signal-primary); }
+body a:hover { color: var(--signal-primary-dark); }
+body table.schedule-table thead th { background: var(--signal-indigo); }
+body > div.component-inherited-content-area:last-of-type {
+  background: var(--signal-ink);
+  border-top: 3px solid var(--signal-primary);
+}
+
+/* ─── 0.0.3 · bugfix: session card height inconsistency ───────────────
+ * The sessions index had 15 cards with varying abstract length. Some
+ * cards were 180px tall, others 280px, breaking the grid rhythm.
+ * Flex-columns + min-height fix this cleanly and push the level tag
+ * + end-time to the bottom of every card. */
+body .signal-card {
+  display: flex;
+  flex-direction: column;
+  min-height: 220px;
+}
+body .signal-card .signal-card-body { flex: 1 1 auto; }
+body .signal-card .signal-card-foot { margin-top: auto; }
+
+/* ─── 0.0.4 · nav hover underline + card elevation ────────────────────
+ * bugfix: nav items had no hover affordance on dark nav.
+ * improvement: cards were flat — add a subtle lift on hover. */
+body > div.component-inherited-content-area:first-of-type a {
+  position: relative;
+  padding-bottom: 0.15rem;
+}
+body > div.component-inherited-content-area:first-of-type a::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -2px;
+  height: 2px;
+  background: var(--signal-primary);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.2s ease;
+}
+body > div.component-inherited-content-area:first-of-type a:hover::after {
+  transform: scaleX(1);
+}
+body .signal-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 18px 36px rgba(7, 8, 20, 0.10);
+  border-color: rgba(255, 106, 74, 0.35);
+}
+
+/* ─── 0.1.0 · schedule legend + border accents ────────────────────────
+ * Minor release. Adds a small legend row above each day's schedule
+ * table explaining the level tags. Also introduces a left-accent
+ * border on hovered schedule rows in brand red. */
+body .schedule-day {
+  position: relative;
+}
+body .schedule-day h3 + table.schedule-table {
+  margin-top: 1.25rem;
+}
+body .schedule-day h3::after {
+  content: 'Intro · Intermediate · Advanced · levels are a rough guide';
+  display: block;
+  font-size: 0.72rem;
+  font-weight: 500;
+  font-family: 'Inter', sans-serif;
+  color: var(--signal-indigo-2);
+  letter-spacing: 0.05em;
+  margin-top: 0.35rem;
+  text-transform: none;
+}
+body table.schedule-table tbody tr {
+  position: relative;
+  transition: background 0.15s ease, box-shadow 0.15s ease;
+}
+body table.schedule-table tbody tr:hover {
+  background: rgba(255, 106, 74, 0.05);
+  box-shadow: inset 3px 0 0 0 var(--signal-primary);
+}
+
+/* Speaker card avatar bounce on card hover */
+body .signal-card:hover .signal-avatar {
+  transform: scale(1.06) rotate(-3deg);
+  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+body .signal-avatar { transition: transform 0.25s ease; }
+
+/* ─── 1.0.0 · typography ramp, tokens, unified spacing ────────────────
+ * Major release. Introduces a full token system + refined modular
+ * type scale. Visible effect: tighter hero, more breathing room in
+ * cards, and a cleaner footer. */
+:root {
+  --signal-font-display: 'Georgia', 'Libre Caslon Text', 'Baskerville', serif;
+  --signal-font-body:    'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --signal-text:         #1c1f2a;
+  --signal-text-soft:    #5c6376;
+  --signal-border:       #e8e9f0;
+  --signal-radius:       16px;
+  --signal-radius-lg:    22px;
+  --signal-space-1: 0.5rem;
+  --signal-space-2: 1rem;
+  --signal-space-3: 1.5rem;
+  --signal-space-4: 2.25rem;
+  --signal-space-5: 3.5rem;
+  --signal-space-6: 5.5rem;
+  --signal-space-7: 8rem;
+  --signal-step-1: 0.78rem;
+  --signal-step-2: 0.92rem;
+  --signal-step-3: 1.08rem;
+  --signal-step-4: 1.32rem;
+  --signal-step-5: 1.85rem;
+  --signal-step-6: 2.6rem;
+  --signal-step-7: 3.9rem;
+  --signal-step-8: 5.2rem;
+}
+
+body {
+  font-family: var(--signal-font-body);
+  font-size: var(--signal-step-3);
+  color: var(--signal-text);
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) {
+  padding: var(--signal-space-7) var(--signal-space-4) calc(var(--signal-space-7) - 1rem);
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) h1 {
+  font-size: var(--signal-step-8);
+  max-width: 14ch;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) {
+  padding: var(--signal-space-6) var(--signal-space-4);
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) h2 {
+  font-size: var(--signal-step-7);
+  letter-spacing: -0.02em;
+}
+
+body .signal-card {
+  padding: var(--signal-space-3);
+  border-radius: var(--signal-radius);
+  border-color: var(--signal-border);
+  gap: 0.5rem;
+}
+body .signal-card h3 {
+  font-family: var(--signal-font-display);
+  font-size: var(--signal-step-4);
+  font-weight: 700;
+  letter-spacing: -0.005em;
+}
+
+body .signal-avatar {
+  width: 52px;
+  height: 52px;
+  font-size: var(--signal-step-3);
+}
+
+body .signal-stat .signal-stat-value {
+  font-family: var(--signal-font-display);
+  font-size: var(--signal-step-6);
+}
+body .signal-stat-grid { gap: var(--signal-space-2); }
+
+body table.schedule-table {
+  border-radius: var(--signal-radius);
+  font-size: var(--signal-step-2);
+}
+body table.schedule-table thead th {
+  padding: var(--signal-space-2) var(--signal-space-3);
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+}
+body table.schedule-table td {
+  padding: var(--signal-space-2) var(--signal-space-3);
+}
+
+/* Footer: more breathing room + softer separator */
+body > div.component-inherited-content-area:last-of-type {
+  padding: var(--signal-space-6) var(--signal-space-4) var(--signal-space-4);
+}
+body > div.component-inherited-content-area:last-of-type h4,
+body > div.component-inherited-content-area:last-of-type h5 {
+  font-family: var(--signal-font-body);
+  letter-spacing: 0.14em;
+}

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/1.1.0/.content.xml
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/1.1.0/.content.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:kes="http://kestros.io/kes/1.0"
+          jcr:primaryType="kes:UiFramework"
+          jcr:title="Signal Framework 1.1.0"
+          jcr:description="Live stream + video archive — video embed treatment and archive list."
+          kes:uiFrameworkCode="signal-framework"
+          kes:vendorLibraries="[ui-kit/3.23.6]"
+/>

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/1.1.0/themes/default/.content.xml
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/1.1.0/themes/default/.content.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:kes="http://kestros.io/kes/1.0"
+          jcr:primaryType="kes:Theme"
+          jcr:title="Default"
+/>

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/1.1.0/themes/default/css/.content.xml
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/1.1.0/themes/default/css/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="sling:OrderedFolder"
+          include="[main.css]"
+/>

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/1.1.0/themes/default/css/main.css
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/1.1.0/themes/default/css/main.css
@@ -1,0 +1,944 @@
+body { margin: 0; }
+body .ui.menu { display: none; }
+body .ui.container { max-width: 1080px; margin: 0 auto; padding: 0 2rem; }
+/* signal-conf theme overlay on the semantic-ui default theme.
+ *
+ * Semantic UI has a strong built-in look, but Kestros components
+ * can't pass UIKit-style modifier classes through inlineVariations
+ * (it's a variation-name lookup, not raw class pass-through). So
+ * this file targets the concrete markup the signal-conf site emits
+ * and applies the finishing layer directly — dark conference hero,
+ * bold editorial typography, card grids for speakers/sessions, and
+ * a sticky schedule table.
+ */
+
+/* ─── Base typography ─────────────────────────────────────────────────── */
+body {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Roboto, Helvetica, Arial, sans-serif;
+  color: #1a1d26;
+  background: #ffffff;
+  line-height: 1.55;
+}
+a { color: #e8513f; text-decoration: none; }
+a:hover { color: #b33626; }
+h1, h2, h3, h4 { font-family: 'Inter', -apple-system, sans-serif; color: #0b0d14; }
+
+/* ─── Top navigation ──────────────────────────────────────────────────── */
+body > div.component-inherited-content-area:first-of-type {
+  background: #0b0d14;
+  padding: 1.1rem 2.5rem;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  border-bottom: 1px solid #1e2130;
+}
+body > div.component-inherited-content-area:first-of-type::before {
+  content: 'SIGNAL';
+  position: absolute;
+  left: 2.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-weight: 900;
+  letter-spacing: 0.22em;
+  font-size: 1rem;
+  color: #e8513f;
+}
+body > div.component-inherited-content-area:first-of-type .ui.menu,
+body > div.component-inherited-content-area:first-of-type .ui.menu .item {
+  background: transparent !important;
+  border: none !important;
+  padding-left: 0;
+}
+body > div.component-inherited-content-area:first-of-type a {
+  color: #c8cbd6;
+  text-decoration: none;
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  margin-left: 1.75rem;
+}
+body > div.component-inherited-content-area:first-of-type a:hover {
+  color: #ffffff;
+}
+/* Push the nav items to the right to leave room for the SIGNAL wordmark */
+body > div.component-inherited-content-area:first-of-type > .component-content-area,
+body > div.component-inherited-content-area:first-of-type > div:not(.component-inherited-content-area) {
+  text-align: right;
+}
+
+/* ─── Sections — first is hero, rest alternate ────────────────────────── */
+body > div:not(.component-inherited-content-area),
+body > div.ui.container,
+body > section,
+body > div[class*="section"] {
+  /* noop — Kestros structure/section outputs some vendor-specific class */
+}
+
+/* The Kestros structure/section HTL on semantic-ui wraps content in a
+ * <div class="ui segment ${section.inlineVariations}">. We want full-
+ * bleed hero + regular content sections. */
+body > div:not(.component-inherited-content-area) {
+  padding: 4rem 2rem;
+  background: #ffffff;
+  border: none !important;
+  box-shadow: none !important;
+  margin: 0 !important;
+  border-radius: 0 !important;
+}
+
+/* First segment after header — dark editorial hero */
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) {
+  background: #0b0d14 !important;
+  color: #ffffff;
+  padding: 8rem 2rem 7rem;
+  position: relative;
+  overflow: hidden;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area)::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 18% 28%, rgba(232, 81, 63, 0.25) 0%, transparent 45%),
+    radial-gradient(circle at 82% 72%, rgba(76, 127, 226, 0.22) 0%, transparent 45%),
+    radial-gradient(circle at 50% 100%, rgba(255, 183, 77, 0.12) 0%, transparent 55%);
+  pointer-events: none;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) > * {
+  position: relative;
+  z-index: 1;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) h1 {
+  color: #ffffff;
+  font-size: 4.25rem;
+  line-height: 0.98;
+  letter-spacing: -0.035em;
+  font-weight: 900;
+  margin: 1rem auto 1.25rem;
+  max-width: 1000px;
+  text-align: center;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) h2 {
+  color: #ffffff;
+  font-size: 2.75rem;
+  line-height: 1;
+  font-weight: 800;
+  text-align: center;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) p {
+  color: rgba(255, 255, 255, 0.78);
+  font-size: 1.2rem;
+  max-width: 720px;
+  margin: 0.75rem auto 1.5rem;
+  text-align: center;
+  line-height: 1.55;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) .component-text:first-child p {
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  font-size: 0.8rem;
+  color: #e8513f;
+  margin-bottom: 0.25rem;
+}
+
+/* Non-hero section containers */
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) {
+  background: #ffffff;
+}
+body > div:nth-child(4):not(.component-inherited-content-area),
+body > div:nth-child(6):not(.component-inherited-content-area),
+body > div:nth-child(8):not(.component-inherited-content-area),
+body > div:nth-child(10):not(.component-inherited-content-area),
+body > div:nth-child(12):not(.component-inherited-content-area),
+body > div:nth-child(14):not(.component-inherited-content-area) {
+  background: #f5f6fa;
+}
+
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) h2 {
+  font-size: 2.25rem;
+  font-weight: 800;
+  letter-spacing: -0.015em;
+  text-align: center;
+  margin: 0 auto 2rem;
+  max-width: 800px;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) .component-text:first-child p {
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.78rem;
+  color: #e8513f;
+  font-weight: 700;
+  margin-bottom: 0.4rem;
+}
+
+body > div:not(.component-inherited-content-area) > .ui.container {
+  max-width: 1080px;
+  margin: 0 auto;
+}
+
+/* ─── Button group → conference pill buttons ──────────────────────────── */
+body div[class*="uk-button-group"],
+body .component-button-group {
+  text-align: center;
+  margin-top: 1.75rem;
+}
+body a.ui.button,
+body .component-button-group a {
+  display: inline-block;
+  background: #e8513f;
+  color: #ffffff !important;
+  padding: 0.95rem 1.85rem;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  text-decoration: none;
+  margin: 0 0.4rem 0 0;
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+body a.ui.button:hover,
+body .component-button-group a:hover {
+  background: #b33626;
+  transform: translateY(-1px);
+}
+body .component-button-group a + a {
+  background: transparent;
+  color: #ffffff !important;
+  border: 1px solid rgba(255, 255, 255, 0.55);
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) .component-button-group a + a {
+  color: #0b0d14 !important;
+  border: 1px solid #0b0d14;
+}
+
+/* ─── Richtext flex/grid handling (see league-theme for rationale) ────── */
+body .component-richtext > div > div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  margin: 1.5rem auto 0;
+  justify-content: center;
+}
+body .component-richtext > div > div > table,
+body .component-richtext > div > table,
+body .component-richtext > div > ul,
+body .component-richtext > div > ol,
+body .component-richtext > div > h2,
+body .component-richtext > div > h3,
+body .component-richtext > div > h4,
+body .component-richtext > div > p {
+  display: initial;
+}
+body .component-richtext > div:has(> table),
+body .component-richtext > div:has(> ul),
+body .component-richtext > div:has(> ol),
+body .component-richtext > div:has(> h2),
+body .component-richtext > div:has(> h3) {
+  display: block;
+}
+
+/* Sponsors & schedule-day blocks need block layout (full-width tiers
+ * and day tables, not a flex row of tiers). */
+body .component-richtext > div > div:has(> .sponsors-tier),
+body .component-richtext > div > div:has(> .schedule-day),
+body .component-richtext > div > div:has(> table),
+body .component-richtext > div > div:has(> .past-editions-table) {
+  display: block;
+}
+body .component-richtext > div > div > div:not([class*="ui-grid"]):not([class*="uk-grid"]):not([class*="uk-child-width"]):not([class*="uk-flex"]):not(.sponsors-tier):not(.schedule-day):not(.signal-venue):not(.signal-stat-grid) {
+  flex: 1 1 280px;
+  max-width: 340px;
+}
+/* Full-width blocks inside a block-display wrapper */
+body .component-richtext > div > div > .sponsors-tier,
+body .component-richtext > div > div > .schedule-day,
+body .component-richtext > div > div > .signal-venue,
+body .component-richtext > div > div > .signal-stat-grid {
+  flex: none;
+  max-width: none;
+  width: 100%;
+}
+
+/* ─── Cards (speakers / sessions / sponsors) ──────────────────────────── */
+body .signal-card {
+  background: #ffffff;
+  border: 1px solid #e2e4ec;
+  border-radius: 14px;
+  padding: 1.5rem 1.4rem;
+  box-shadow: 0 1px 2px rgba(20, 24, 36, 0.03);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+body .signal-card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 14px 32px rgba(20, 24, 36, 0.09);
+  border-color: #cdd1dc;
+}
+body .signal-card h3 {
+  margin: 0.1rem 0 0;
+  font-size: 1.2rem;
+  font-weight: 800;
+  color: #0b0d14;
+  letter-spacing: -0.01em;
+}
+body .signal-card .signal-card-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.68rem;
+  color: #e8513f;
+  font-weight: 700;
+}
+body .signal-card .signal-card-sub {
+  color: #5c6376;
+  font-size: 0.92rem;
+}
+body .signal-card .signal-card-body {
+  color: #3a404f;
+  font-size: 0.92rem;
+  margin-top: 0.35rem;
+}
+body .signal-card .signal-card-foot {
+  margin-top: auto;
+  padding-top: 0.75rem;
+  border-top: 1px solid #eef0f5;
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  color: #5c6376;
+}
+body .signal-card .signal-tag {
+  display: inline-block;
+  background: #f1f2f7;
+  color: #3a404f;
+  padding: 0.15rem 0.6rem;
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-radius: 999px;
+}
+body .signal-card .signal-tag.is-intro       { background: #e9f6ef; color: #1d7041; }
+body .signal-card .signal-tag.is-intermediate{ background: #fdf4d6; color: #7a5512; }
+body .signal-card .signal-tag.is-advanced    { background: #fbe5e2; color: #8a2418; }
+
+/* Speaker avatar = initials circle on a brand-red disc */
+body .signal-avatar {
+  width: 56px;
+  height: 56px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #e8513f, #b33626);
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 900;
+  font-size: 1.15rem;
+  letter-spacing: 0.02em;
+  flex-shrink: 0;
+}
+
+/* ─── Schedule table ──────────────────────────────────────────────────── */
+body .schedule-day {
+  margin: 2rem auto 2.5rem;
+}
+body .schedule-day h3 {
+  text-align: center;
+  font-size: 1.55rem;
+  font-weight: 800;
+  color: #0b0d14;
+  margin: 0 0 1rem;
+  letter-spacing: -0.01em;
+}
+body table.schedule-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92rem;
+  background: #ffffff;
+  border: 1px solid #e2e4ec;
+  border-radius: 12px;
+  overflow: hidden;
+}
+body table.schedule-table thead th {
+  background: #0b0d14;
+  color: #ffffff;
+  text-align: left;
+  padding: 0.85rem 1rem;
+  font-weight: 700;
+  font-size: 0.76rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+body table.schedule-table td {
+  padding: 0.95rem 1rem;
+  border-bottom: 1px solid #e8eaf0;
+  vertical-align: top;
+}
+body table.schedule-table tr:last-child td { border-bottom: none; }
+body table.schedule-table tr:nth-child(even) td { background: #f8f9fc; }
+body table.schedule-table td.schedule-time {
+  font-weight: 700;
+  color: #0b0d14;
+  white-space: nowrap;
+  width: 110px;
+}
+body table.schedule-table td.schedule-track {
+  color: #5c6376;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+  width: 130px;
+}
+body table.schedule-table td.schedule-title strong {
+  display: block;
+  color: #0b0d14;
+  font-size: 1rem;
+  font-weight: 700;
+}
+body table.schedule-table td.schedule-title .schedule-speaker {
+  color: #5c6376;
+  font-size: 0.85rem;
+  margin-top: 0.15rem;
+}
+
+/* ─── Session + speaker + venue details ───────────────────────────────── */
+body .signal-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  max-width: 900px;
+  margin: 1.5rem auto;
+}
+body .signal-stat-grid .signal-stat {
+  background: #ffffff;
+  border: 1px solid #e2e4ec;
+  border-radius: 12px;
+  padding: 1.35rem 1.2rem;
+  text-align: center;
+}
+body .signal-stat .signal-stat-label {
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.7rem;
+  color: #5c6376;
+  font-weight: 700;
+}
+body .signal-stat .signal-stat-value {
+  font-size: 2rem;
+  font-weight: 900;
+  color: #0b0d14;
+  margin-top: 0.3rem;
+  letter-spacing: -0.015em;
+}
+
+/* ─── Sponsors tier grid ──────────────────────────────────────────────── */
+body .sponsors-tier {
+  text-align: center;
+  margin: 1.75rem 0;
+}
+body .sponsors-tier h3 {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: #5c6376;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+body .sponsor-logos {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 1.5rem;
+}
+body .sponsor-logos .sponsor {
+  background: #ffffff;
+  border: 1px solid #e2e4ec;
+  border-radius: 12px;
+  padding: 1rem 1.6rem;
+  font-weight: 800;
+  color: #0b0d14;
+  letter-spacing: -0.01em;
+  min-width: 160px;
+  text-align: center;
+}
+body .sponsor-logos .sponsor.tier-gold { font-size: 1.4rem; padding: 1.6rem 2.2rem; }
+body .sponsor-logos .sponsor.tier-silver { font-size: 1.1rem; padding: 1.2rem 1.8rem; }
+body .sponsor-logos .sponsor.tier-bronze { font-size: 0.95rem; opacity: 0.85; }
+
+/* ─── Venue map-ish block ─────────────────────────────────────────────── */
+body .signal-venue {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+  max-width: 960px;
+  margin: 1.5rem auto;
+  align-items: stretch;
+}
+body .signal-venue .signal-venue-map {
+  background: linear-gradient(135deg, #0b0d14 0%, #1c2133 60%, #2d3657 100%);
+  border-radius: 16px;
+  min-height: 340px;
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #ffffff;
+}
+body .signal-venue .signal-venue-map::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(135deg, transparent 48%, rgba(232, 81, 63, 0.12) 48%, rgba(232, 81, 63, 0.12) 52%, transparent 52%),
+    linear-gradient(45deg, transparent 48%, rgba(76, 127, 226, 0.1) 48%, rgba(76, 127, 226, 0.1) 52%, transparent 52%);
+}
+body .signal-venue .signal-venue-map .signal-venue-pin {
+  position: relative;
+  z-index: 1;
+  background: #e8513f;
+  border-radius: 999px;
+  padding: 0.6rem 1.2rem;
+  font-weight: 800;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  box-shadow: 0 6px 18px rgba(232, 81, 63, 0.4);
+}
+body .signal-venue .signal-venue-info h3 {
+  font-size: 1.4rem;
+  margin: 0 0 0.5rem;
+}
+body .signal-venue .signal-venue-info p {
+  color: #3a404f;
+  margin: 0 0 1rem;
+  line-height: 1.55;
+}
+
+/* ─── Footer ──────────────────────────────────────────────────────────── */
+body > div.component-inherited-content-area:last-of-type {
+  background: #0b0d14;
+  color: rgba(255, 255, 255, 0.72);
+  padding: 3.5rem 2rem 2rem;
+}
+body > div.component-inherited-content-area:last-of-type .ui.segment,
+body > div.component-inherited-content-area:last-of-type > div[class*="segment"] {
+  background: transparent !important;
+  padding: 0 !important;
+}
+body > div.component-inherited-content-area:last-of-type h4,
+body > div.component-inherited-content-area:last-of-type h5 {
+  color: #ffffff;
+  font-size: 0.82rem;
+  margin: 0 0 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 700;
+}
+body > div.component-inherited-content-area:last-of-type a {
+  color: rgba(255, 255, 255, 0.72);
+}
+body > div.component-inherited-content-area:last-of-type a:hover {
+  color: #ffffff;
+}
+body > div.component-inherited-content-area:last-of-type ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+body > div.component-inherited-content-area:last-of-type li {
+  padding: 0.25rem 0;
+  font-size: 0.88rem;
+}
+body > div.component-inherited-content-area:last-of-type .component-richtext > div > div {
+  display: grid !important;
+  grid-template-columns: 2fr 1fr 1fr 1fr;
+  gap: 2rem;
+  max-width: 1080px;
+  margin: 0 auto;
+}
+body > div.component-inherited-content-area:last-of-type .component-richtext > div > div > div {
+  max-width: none !important;
+  flex: none !important;
+}
+body > div.component-inherited-content-area:last-of-type hr {
+  border: none;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  margin: 2rem 0 1rem;
+  max-width: 1080px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* ─── Past-editions table ─────────────────────────────────────────────── */
+body .past-editions-table {
+  width: 100%;
+  max-width: 860px;
+  margin: 1rem auto;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+body .past-editions-table td,
+body .past-editions-table th {
+  padding: 0.85rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid #e8eaf0;
+}
+body .past-editions-table th {
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 0.76rem;
+  letter-spacing: 0.08em;
+  color: #5c6376;
+}
+body .past-editions-table strong { color: #0b0d14; }
+
+/* ─── Small utilities the pages use ───────────────────────────────────── */
+body .signal-center { text-align: center; }
+body .signal-muted { color: #5c6376; }
+body .signal-strong { font-weight: 700; color: #0b0d14; }
+
+
+/* ─── signal-framework 0.0.2 customizations ──────────────────────────
+ * Editorial indigo + red palette, serif display headlines, aurora hero. */
+:root {
+  --signal-primary:     #ff6a4a;
+  --signal-primary-dark:#c23b1d;
+  --signal-ink:         #070814;
+  --signal-indigo:      #1c1f46;
+  --signal-indigo-2:    #2a2e68;
+  --signal-cream:       #f8f5ee;
+}
+body { background: #ffffff; color: #1c1f2a; }
+body > div.component-inherited-content-area:first-of-type { background: var(--signal-ink); }
+body > div.component-inherited-content-area:first-of-type::before { color: var(--signal-primary); }
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) {
+  background: var(--signal-ink) !important;
+  padding: 9rem 2rem 8rem;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area)::before {
+  background:
+    radial-gradient(ellipse 60% 40% at 20% 30%, rgba(255, 106, 74, 0.28) 0%, transparent 60%),
+    radial-gradient(ellipse 50% 60% at 78% 68%, rgba(84, 70, 220, 0.32) 0%, transparent 55%),
+    radial-gradient(ellipse 70% 40% at 50% 100%, rgba(255, 182, 72, 0.14) 0%, transparent 60%),
+    linear-gradient(180deg, var(--signal-ink) 0%, var(--signal-indigo) 100%);
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) h1 {
+  font-family: 'Georgia', 'Libre Caslon Text', 'Baskerville', serif;
+  font-weight: 700;
+  font-size: 4.5rem;
+  letter-spacing: -0.025em;
+  line-height: 0.98;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) .component-text:first-child p {
+  color: var(--signal-primary);
+  font-family: -apple-system, 'Inter', sans-serif;
+  font-weight: 700;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) h2 {
+  font-family: 'Georgia', serif;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) .component-text:first-child p {
+  color: var(--signal-primary);
+}
+body a.ui.button,
+body .component-button-group a {
+  background: linear-gradient(135deg, var(--signal-primary) 0%, var(--signal-primary-dark) 100%);
+  box-shadow: 0 6px 18px rgba(255, 106, 74, 0.3);
+}
+body a.ui.button:hover,
+body .component-button-group a:hover {
+  background: linear-gradient(135deg, var(--signal-primary-dark) 0%, #8c220c 100%);
+}
+body > div:nth-child(4):not(.component-inherited-content-area),
+body > div:nth-child(6):not(.component-inherited-content-area),
+body > div:nth-child(8):not(.component-inherited-content-area),
+body > div:nth-child(10):not(.component-inherited-content-area),
+body > div:nth-child(12):not(.component-inherited-content-area),
+body > div:nth-child(14):not(.component-inherited-content-area) {
+  background: var(--signal-cream);
+}
+body .signal-card-eyebrow { color: var(--signal-primary); }
+body .signal-avatar { background: linear-gradient(135deg, var(--signal-primary), var(--signal-primary-dark)); }
+body a { color: var(--signal-primary); }
+body a:hover { color: var(--signal-primary-dark); }
+body table.schedule-table thead th { background: var(--signal-indigo); }
+body > div.component-inherited-content-area:last-of-type {
+  background: var(--signal-ink);
+  border-top: 3px solid var(--signal-primary);
+}
+
+/* ─── 0.0.3 · bugfix: session card height inconsistency ───────────────
+ * The sessions index had 15 cards with varying abstract length. Some
+ * cards were 180px tall, others 280px, breaking the grid rhythm.
+ * Flex-columns + min-height fix this cleanly and push the level tag
+ * + end-time to the bottom of every card. */
+body .signal-card {
+  display: flex;
+  flex-direction: column;
+  min-height: 220px;
+}
+body .signal-card .signal-card-body { flex: 1 1 auto; }
+body .signal-card .signal-card-foot { margin-top: auto; }
+
+/* ─── 0.0.4 · nav hover underline + card elevation ────────────────────
+ * bugfix: nav items had no hover affordance on dark nav.
+ * improvement: cards were flat — add a subtle lift on hover. */
+body > div.component-inherited-content-area:first-of-type a {
+  position: relative;
+  padding-bottom: 0.15rem;
+}
+body > div.component-inherited-content-area:first-of-type a::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -2px;
+  height: 2px;
+  background: var(--signal-primary);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.2s ease;
+}
+body > div.component-inherited-content-area:first-of-type a:hover::after {
+  transform: scaleX(1);
+}
+body .signal-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 18px 36px rgba(7, 8, 20, 0.10);
+  border-color: rgba(255, 106, 74, 0.35);
+}
+
+/* ─── 0.1.0 · schedule legend + border accents ────────────────────────
+ * Minor release. Adds a small legend row above each day's schedule
+ * table explaining the level tags. Also introduces a left-accent
+ * border on hovered schedule rows in brand red. */
+body .schedule-day {
+  position: relative;
+}
+body .schedule-day h3 + table.schedule-table {
+  margin-top: 1.25rem;
+}
+body .schedule-day h3::after {
+  content: 'Intro · Intermediate · Advanced · levels are a rough guide';
+  display: block;
+  font-size: 0.72rem;
+  font-weight: 500;
+  font-family: 'Inter', sans-serif;
+  color: var(--signal-indigo-2);
+  letter-spacing: 0.05em;
+  margin-top: 0.35rem;
+  text-transform: none;
+}
+body table.schedule-table tbody tr {
+  position: relative;
+  transition: background 0.15s ease, box-shadow 0.15s ease;
+}
+body table.schedule-table tbody tr:hover {
+  background: rgba(255, 106, 74, 0.05);
+  box-shadow: inset 3px 0 0 0 var(--signal-primary);
+}
+
+/* Speaker card avatar bounce on card hover */
+body .signal-card:hover .signal-avatar {
+  transform: scale(1.06) rotate(-3deg);
+  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+body .signal-avatar { transition: transform 0.25s ease; }
+
+/* ─── 1.0.0 · typography ramp, tokens, unified spacing ────────────────
+ * Major release. Introduces a full token system + refined modular
+ * type scale. Visible effect: tighter hero, more breathing room in
+ * cards, and a cleaner footer. */
+:root {
+  --signal-font-display: 'Georgia', 'Libre Caslon Text', 'Baskerville', serif;
+  --signal-font-body:    'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --signal-text:         #1c1f2a;
+  --signal-text-soft:    #5c6376;
+  --signal-border:       #e8e9f0;
+  --signal-radius:       16px;
+  --signal-radius-lg:    22px;
+  --signal-space-1: 0.5rem;
+  --signal-space-2: 1rem;
+  --signal-space-3: 1.5rem;
+  --signal-space-4: 2.25rem;
+  --signal-space-5: 3.5rem;
+  --signal-space-6: 5.5rem;
+  --signal-space-7: 8rem;
+  --signal-step-1: 0.78rem;
+  --signal-step-2: 0.92rem;
+  --signal-step-3: 1.08rem;
+  --signal-step-4: 1.32rem;
+  --signal-step-5: 1.85rem;
+  --signal-step-6: 2.6rem;
+  --signal-step-7: 3.9rem;
+  --signal-step-8: 5.2rem;
+}
+
+body {
+  font-family: var(--signal-font-body);
+  font-size: var(--signal-step-3);
+  color: var(--signal-text);
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) {
+  padding: var(--signal-space-7) var(--signal-space-4) calc(var(--signal-space-7) - 1rem);
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) h1 {
+  font-size: var(--signal-step-8);
+  max-width: 14ch;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) {
+  padding: var(--signal-space-6) var(--signal-space-4);
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) h2 {
+  font-size: var(--signal-step-7);
+  letter-spacing: -0.02em;
+}
+
+body .signal-card {
+  padding: var(--signal-space-3);
+  border-radius: var(--signal-radius);
+  border-color: var(--signal-border);
+  gap: 0.5rem;
+}
+body .signal-card h3 {
+  font-family: var(--signal-font-display);
+  font-size: var(--signal-step-4);
+  font-weight: 700;
+  letter-spacing: -0.005em;
+}
+
+body .signal-avatar {
+  width: 52px;
+  height: 52px;
+  font-size: var(--signal-step-3);
+}
+
+body .signal-stat .signal-stat-value {
+  font-family: var(--signal-font-display);
+  font-size: var(--signal-step-6);
+}
+body .signal-stat-grid { gap: var(--signal-space-2); }
+
+body table.schedule-table {
+  border-radius: var(--signal-radius);
+  font-size: var(--signal-step-2);
+}
+body table.schedule-table thead th {
+  padding: var(--signal-space-2) var(--signal-space-3);
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+}
+body table.schedule-table td {
+  padding: var(--signal-space-2) var(--signal-space-3);
+}
+
+/* Footer: more breathing room + softer separator */
+body > div.component-inherited-content-area:last-of-type {
+  padding: var(--signal-space-6) var(--signal-space-4) var(--signal-space-4);
+}
+body > div.component-inherited-content-area:last-of-type h4,
+body > div.component-inherited-content-area:last-of-type h5 {
+  font-family: var(--signal-font-body);
+  letter-spacing: 0.14em;
+}
+
+/* ─── 1.1.0 · sticky day jumps + polish ───────────────────────────────
+ * Adds a sticky day-jump row to the schedule page, and new styles
+ * for the sponsor monogram cards, the speaker/session filter bar,
+ * and a couple of speaker-card refinements for the new 12-card grid.
+ */
+
+/* Schedule day-jump — wrap schedule-day h3s in a sticky strip */
+body .schedule-day {
+  scroll-margin-top: 5rem;
+}
+body .schedule-day h3 {
+  position: sticky;
+  top: 4.25rem;
+  background: rgba(255, 255, 255, 0.94);
+  backdrop-filter: blur(6px);
+  padding: 1rem 0 0.75rem;
+  z-index: 10;
+  border-bottom: 1px solid #e8e9f0;
+}
+
+/* Sponsor monogram cards */
+body .sponsor {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 1.4rem 1.6rem 1.25rem;
+  background: #ffffff;
+  border: 1px solid #e2e4ec;
+  border-radius: 16px;
+  min-width: 180px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+body .sponsor:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 18px 36px rgba(28, 31, 70, 0.08);
+}
+body .sponsor .sponsor-logo-svg {
+  width: 72px;
+  height: 72px;
+  display: block;
+}
+body .sponsor .sponsor-logo-svg svg { width: 100%; height: 100%; }
+body .sponsor .sponsor-name {
+  font-weight: 800;
+  color: var(--signal-text, #1c1f2a);
+  font-size: 0.98rem;
+  text-align: center;
+}
+body .sponsor .sponsor-tagline {
+  color: #5c6376;
+  font-size: 0.78rem;
+  text-align: center;
+  max-width: 15ch;
+}
+body .sponsor.tier-gold .sponsor-logo-svg { width: 88px; height: 88px; }
+body .sponsor.tier-silver .sponsor-logo-svg { width: 68px; height: 68px; }
+body .sponsor.tier-bronze .sponsor-logo-svg { width: 56px; height: 56px; }
+body .sponsor.tier-gold { min-width: 220px; padding: 1.75rem 2rem; }
+body .sponsor.tier-bronze { min-width: 150px; padding: 1.1rem 1.2rem; }
+
+/* Filter button row polish */
+body .signal-filter button[data-signal-filter],
+body .signal-filter button[data-signal-filter-level] {
+  font-family: 'Inter', sans-serif;
+  transition: background 0.15s ease, color 0.15s ease, transform 0.1s ease;
+}
+body .signal-filter button[data-signal-filter]:hover,
+body .signal-filter button[data-signal-filter-level]:hover {
+  transform: translateY(-1px);
+}
+
+/* Venue map svg scale */
+body .signal-venue .signal-venue-map svg.venue-map-svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+body .signal-venue .signal-venue-map {
+  padding: 0;
+  background: transparent;
+}
+body .signal-venue .signal-venue-map::before { display: none; }
+body .signal-venue .signal-venue-map .signal-venue-pin { display: none; }
+
+/* Speaker-card grid — tighter column sizing now that there are 12 */
+body .component-richtext > div > div > div:not([class*="uk-grid"]):not([class*="uk-child-width"]):not([class*="uk-flex"]):not(.sponsors-tier):not(.schedule-day):not(.signal-venue):not(.signal-stat-grid) {
+  flex: 1 1 260px;
+  max-width: 320px;
+}

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/1.2.0/.content.xml
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/1.2.0/.content.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:kes="http://kestros.io/kes/1.0"
+          jcr:primaryType="kes:UiFramework"
+          jcr:title="Signal Framework 1.2.0"
+          jcr:description="Dark mode + responsive — full dark-theme variant with system-preference detection."
+          kes:uiFrameworkCode="signal-framework"
+          kes:vendorLibraries="[ui-kit/3.23.6]"
+/>

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/1.2.0/themes/default/.content.xml
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/1.2.0/themes/default/.content.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:kes="http://kestros.io/kes/1.0"
+          jcr:primaryType="kes:Theme"
+          jcr:title="Default"
+/>

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/1.2.0/themes/default/css/.content.xml
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/1.2.0/themes/default/css/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="sling:OrderedFolder"
+          include="[main.css]"
+/>

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/1.2.0/themes/default/css/main.css
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/1.2.0/themes/default/css/main.css
@@ -1,0 +1,1138 @@
+body { margin: 0; }
+body .ui.menu { display: none; }
+body .ui.container { max-width: 1080px; margin: 0 auto; padding: 0 2rem; }
+/* signal-conf theme overlay on the semantic-ui default theme.
+ *
+ * Semantic UI has a strong built-in look, but Kestros components
+ * can't pass UIKit-style modifier classes through inlineVariations
+ * (it's a variation-name lookup, not raw class pass-through). So
+ * this file targets the concrete markup the signal-conf site emits
+ * and applies the finishing layer directly — dark conference hero,
+ * bold editorial typography, card grids for speakers/sessions, and
+ * a sticky schedule table.
+ */
+
+/* ─── Base typography ─────────────────────────────────────────────────── */
+body {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Roboto, Helvetica, Arial, sans-serif;
+  color: #1a1d26;
+  background: #ffffff;
+  line-height: 1.55;
+}
+a { color: #e8513f; text-decoration: none; }
+a:hover { color: #b33626; }
+h1, h2, h3, h4 { font-family: 'Inter', -apple-system, sans-serif; color: #0b0d14; }
+
+/* ─── Top navigation ──────────────────────────────────────────────────── */
+body > div.component-inherited-content-area:first-of-type {
+  background: #0b0d14;
+  padding: 1.1rem 2.5rem;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  border-bottom: 1px solid #1e2130;
+}
+body > div.component-inherited-content-area:first-of-type::before {
+  content: 'SIGNAL';
+  position: absolute;
+  left: 2.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-weight: 900;
+  letter-spacing: 0.22em;
+  font-size: 1rem;
+  color: #e8513f;
+}
+body > div.component-inherited-content-area:first-of-type .ui.menu,
+body > div.component-inherited-content-area:first-of-type .ui.menu .item {
+  background: transparent !important;
+  border: none !important;
+  padding-left: 0;
+}
+body > div.component-inherited-content-area:first-of-type a {
+  color: #c8cbd6;
+  text-decoration: none;
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  margin-left: 1.75rem;
+}
+body > div.component-inherited-content-area:first-of-type a:hover {
+  color: #ffffff;
+}
+/* Push the nav items to the right to leave room for the SIGNAL wordmark */
+body > div.component-inherited-content-area:first-of-type > .component-content-area,
+body > div.component-inherited-content-area:first-of-type > div:not(.component-inherited-content-area) {
+  text-align: right;
+}
+
+/* ─── Sections — first is hero, rest alternate ────────────────────────── */
+body > div:not(.component-inherited-content-area),
+body > div.ui.container,
+body > section,
+body > div[class*="section"] {
+  /* noop — Kestros structure/section outputs some vendor-specific class */
+}
+
+/* The Kestros structure/section HTL on semantic-ui wraps content in a
+ * <div class="ui segment ${section.inlineVariations}">. We want full-
+ * bleed hero + regular content sections. */
+body > div:not(.component-inherited-content-area) {
+  padding: 4rem 2rem;
+  background: #ffffff;
+  border: none !important;
+  box-shadow: none !important;
+  margin: 0 !important;
+  border-radius: 0 !important;
+}
+
+/* First segment after header — dark editorial hero */
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) {
+  background: #0b0d14 !important;
+  color: #ffffff;
+  padding: 8rem 2rem 7rem;
+  position: relative;
+  overflow: hidden;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area)::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 18% 28%, rgba(232, 81, 63, 0.25) 0%, transparent 45%),
+    radial-gradient(circle at 82% 72%, rgba(76, 127, 226, 0.22) 0%, transparent 45%),
+    radial-gradient(circle at 50% 100%, rgba(255, 183, 77, 0.12) 0%, transparent 55%);
+  pointer-events: none;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) > * {
+  position: relative;
+  z-index: 1;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) h1 {
+  color: #ffffff;
+  font-size: 4.25rem;
+  line-height: 0.98;
+  letter-spacing: -0.035em;
+  font-weight: 900;
+  margin: 1rem auto 1.25rem;
+  max-width: 1000px;
+  text-align: center;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) h2 {
+  color: #ffffff;
+  font-size: 2.75rem;
+  line-height: 1;
+  font-weight: 800;
+  text-align: center;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) p {
+  color: rgba(255, 255, 255, 0.78);
+  font-size: 1.2rem;
+  max-width: 720px;
+  margin: 0.75rem auto 1.5rem;
+  text-align: center;
+  line-height: 1.55;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) .component-text:first-child p {
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  font-size: 0.8rem;
+  color: #e8513f;
+  margin-bottom: 0.25rem;
+}
+
+/* Non-hero section containers */
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) {
+  background: #ffffff;
+}
+body > div:nth-child(4):not(.component-inherited-content-area),
+body > div:nth-child(6):not(.component-inherited-content-area),
+body > div:nth-child(8):not(.component-inherited-content-area),
+body > div:nth-child(10):not(.component-inherited-content-area),
+body > div:nth-child(12):not(.component-inherited-content-area),
+body > div:nth-child(14):not(.component-inherited-content-area) {
+  background: #f5f6fa;
+}
+
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) h2 {
+  font-size: 2.25rem;
+  font-weight: 800;
+  letter-spacing: -0.015em;
+  text-align: center;
+  margin: 0 auto 2rem;
+  max-width: 800px;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) .component-text:first-child p {
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.78rem;
+  color: #e8513f;
+  font-weight: 700;
+  margin-bottom: 0.4rem;
+}
+
+body > div:not(.component-inherited-content-area) > .ui.container {
+  max-width: 1080px;
+  margin: 0 auto;
+}
+
+/* ─── Button group → conference pill buttons ──────────────────────────── */
+body div[class*="uk-button-group"],
+body .component-button-group {
+  text-align: center;
+  margin-top: 1.75rem;
+}
+body a.ui.button,
+body .component-button-group a {
+  display: inline-block;
+  background: #e8513f;
+  color: #ffffff !important;
+  padding: 0.95rem 1.85rem;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  text-decoration: none;
+  margin: 0 0.4rem 0 0;
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+body a.ui.button:hover,
+body .component-button-group a:hover {
+  background: #b33626;
+  transform: translateY(-1px);
+}
+body .component-button-group a + a {
+  background: transparent;
+  color: #ffffff !important;
+  border: 1px solid rgba(255, 255, 255, 0.55);
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) .component-button-group a + a {
+  color: #0b0d14 !important;
+  border: 1px solid #0b0d14;
+}
+
+/* ─── Richtext flex/grid handling (see league-theme for rationale) ────── */
+body .component-richtext > div > div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  margin: 1.5rem auto 0;
+  justify-content: center;
+}
+body .component-richtext > div > div > table,
+body .component-richtext > div > table,
+body .component-richtext > div > ul,
+body .component-richtext > div > ol,
+body .component-richtext > div > h2,
+body .component-richtext > div > h3,
+body .component-richtext > div > h4,
+body .component-richtext > div > p {
+  display: initial;
+}
+body .component-richtext > div:has(> table),
+body .component-richtext > div:has(> ul),
+body .component-richtext > div:has(> ol),
+body .component-richtext > div:has(> h2),
+body .component-richtext > div:has(> h3) {
+  display: block;
+}
+
+/* Sponsors & schedule-day blocks need block layout (full-width tiers
+ * and day tables, not a flex row of tiers). */
+body .component-richtext > div > div:has(> .sponsors-tier),
+body .component-richtext > div > div:has(> .schedule-day),
+body .component-richtext > div > div:has(> table),
+body .component-richtext > div > div:has(> .past-editions-table) {
+  display: block;
+}
+body .component-richtext > div > div > div:not([class*="ui-grid"]):not([class*="uk-grid"]):not([class*="uk-child-width"]):not([class*="uk-flex"]):not(.sponsors-tier):not(.schedule-day):not(.signal-venue):not(.signal-stat-grid) {
+  flex: 1 1 280px;
+  max-width: 340px;
+}
+/* Full-width blocks inside a block-display wrapper */
+body .component-richtext > div > div > .sponsors-tier,
+body .component-richtext > div > div > .schedule-day,
+body .component-richtext > div > div > .signal-venue,
+body .component-richtext > div > div > .signal-stat-grid {
+  flex: none;
+  max-width: none;
+  width: 100%;
+}
+
+/* ─── Cards (speakers / sessions / sponsors) ──────────────────────────── */
+body .signal-card {
+  background: #ffffff;
+  border: 1px solid #e2e4ec;
+  border-radius: 14px;
+  padding: 1.5rem 1.4rem;
+  box-shadow: 0 1px 2px rgba(20, 24, 36, 0.03);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+body .signal-card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 14px 32px rgba(20, 24, 36, 0.09);
+  border-color: #cdd1dc;
+}
+body .signal-card h3 {
+  margin: 0.1rem 0 0;
+  font-size: 1.2rem;
+  font-weight: 800;
+  color: #0b0d14;
+  letter-spacing: -0.01em;
+}
+body .signal-card .signal-card-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.68rem;
+  color: #e8513f;
+  font-weight: 700;
+}
+body .signal-card .signal-card-sub {
+  color: #5c6376;
+  font-size: 0.92rem;
+}
+body .signal-card .signal-card-body {
+  color: #3a404f;
+  font-size: 0.92rem;
+  margin-top: 0.35rem;
+}
+body .signal-card .signal-card-foot {
+  margin-top: auto;
+  padding-top: 0.75rem;
+  border-top: 1px solid #eef0f5;
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  color: #5c6376;
+}
+body .signal-card .signal-tag {
+  display: inline-block;
+  background: #f1f2f7;
+  color: #3a404f;
+  padding: 0.15rem 0.6rem;
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-radius: 999px;
+}
+body .signal-card .signal-tag.is-intro       { background: #e9f6ef; color: #1d7041; }
+body .signal-card .signal-tag.is-intermediate{ background: #fdf4d6; color: #7a5512; }
+body .signal-card .signal-tag.is-advanced    { background: #fbe5e2; color: #8a2418; }
+
+/* Speaker avatar = initials circle on a brand-red disc */
+body .signal-avatar {
+  width: 56px;
+  height: 56px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #e8513f, #b33626);
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 900;
+  font-size: 1.15rem;
+  letter-spacing: 0.02em;
+  flex-shrink: 0;
+}
+
+/* ─── Schedule table ──────────────────────────────────────────────────── */
+body .schedule-day {
+  margin: 2rem auto 2.5rem;
+}
+body .schedule-day h3 {
+  text-align: center;
+  font-size: 1.55rem;
+  font-weight: 800;
+  color: #0b0d14;
+  margin: 0 0 1rem;
+  letter-spacing: -0.01em;
+}
+body table.schedule-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92rem;
+  background: #ffffff;
+  border: 1px solid #e2e4ec;
+  border-radius: 12px;
+  overflow: hidden;
+}
+body table.schedule-table thead th {
+  background: #0b0d14;
+  color: #ffffff;
+  text-align: left;
+  padding: 0.85rem 1rem;
+  font-weight: 700;
+  font-size: 0.76rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+body table.schedule-table td {
+  padding: 0.95rem 1rem;
+  border-bottom: 1px solid #e8eaf0;
+  vertical-align: top;
+}
+body table.schedule-table tr:last-child td { border-bottom: none; }
+body table.schedule-table tr:nth-child(even) td { background: #f8f9fc; }
+body table.schedule-table td.schedule-time {
+  font-weight: 700;
+  color: #0b0d14;
+  white-space: nowrap;
+  width: 110px;
+}
+body table.schedule-table td.schedule-track {
+  color: #5c6376;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+  width: 130px;
+}
+body table.schedule-table td.schedule-title strong {
+  display: block;
+  color: #0b0d14;
+  font-size: 1rem;
+  font-weight: 700;
+}
+body table.schedule-table td.schedule-title .schedule-speaker {
+  color: #5c6376;
+  font-size: 0.85rem;
+  margin-top: 0.15rem;
+}
+
+/* ─── Session + speaker + venue details ───────────────────────────────── */
+body .signal-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  max-width: 900px;
+  margin: 1.5rem auto;
+}
+body .signal-stat-grid .signal-stat {
+  background: #ffffff;
+  border: 1px solid #e2e4ec;
+  border-radius: 12px;
+  padding: 1.35rem 1.2rem;
+  text-align: center;
+}
+body .signal-stat .signal-stat-label {
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.7rem;
+  color: #5c6376;
+  font-weight: 700;
+}
+body .signal-stat .signal-stat-value {
+  font-size: 2rem;
+  font-weight: 900;
+  color: #0b0d14;
+  margin-top: 0.3rem;
+  letter-spacing: -0.015em;
+}
+
+/* ─── Sponsors tier grid ──────────────────────────────────────────────── */
+body .sponsors-tier {
+  text-align: center;
+  margin: 1.75rem 0;
+}
+body .sponsors-tier h3 {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: #5c6376;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+body .sponsor-logos {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 1.5rem;
+}
+body .sponsor-logos .sponsor {
+  background: #ffffff;
+  border: 1px solid #e2e4ec;
+  border-radius: 12px;
+  padding: 1rem 1.6rem;
+  font-weight: 800;
+  color: #0b0d14;
+  letter-spacing: -0.01em;
+  min-width: 160px;
+  text-align: center;
+}
+body .sponsor-logos .sponsor.tier-gold { font-size: 1.4rem; padding: 1.6rem 2.2rem; }
+body .sponsor-logos .sponsor.tier-silver { font-size: 1.1rem; padding: 1.2rem 1.8rem; }
+body .sponsor-logos .sponsor.tier-bronze { font-size: 0.95rem; opacity: 0.85; }
+
+/* ─── Venue map-ish block ─────────────────────────────────────────────── */
+body .signal-venue {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+  max-width: 960px;
+  margin: 1.5rem auto;
+  align-items: stretch;
+}
+body .signal-venue .signal-venue-map {
+  background: linear-gradient(135deg, #0b0d14 0%, #1c2133 60%, #2d3657 100%);
+  border-radius: 16px;
+  min-height: 340px;
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #ffffff;
+}
+body .signal-venue .signal-venue-map::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(135deg, transparent 48%, rgba(232, 81, 63, 0.12) 48%, rgba(232, 81, 63, 0.12) 52%, transparent 52%),
+    linear-gradient(45deg, transparent 48%, rgba(76, 127, 226, 0.1) 48%, rgba(76, 127, 226, 0.1) 52%, transparent 52%);
+}
+body .signal-venue .signal-venue-map .signal-venue-pin {
+  position: relative;
+  z-index: 1;
+  background: #e8513f;
+  border-radius: 999px;
+  padding: 0.6rem 1.2rem;
+  font-weight: 800;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  box-shadow: 0 6px 18px rgba(232, 81, 63, 0.4);
+}
+body .signal-venue .signal-venue-info h3 {
+  font-size: 1.4rem;
+  margin: 0 0 0.5rem;
+}
+body .signal-venue .signal-venue-info p {
+  color: #3a404f;
+  margin: 0 0 1rem;
+  line-height: 1.55;
+}
+
+/* ─── Footer ──────────────────────────────────────────────────────────── */
+body > div.component-inherited-content-area:last-of-type {
+  background: #0b0d14;
+  color: rgba(255, 255, 255, 0.72);
+  padding: 3.5rem 2rem 2rem;
+}
+body > div.component-inherited-content-area:last-of-type .ui.segment,
+body > div.component-inherited-content-area:last-of-type > div[class*="segment"] {
+  background: transparent !important;
+  padding: 0 !important;
+}
+body > div.component-inherited-content-area:last-of-type h4,
+body > div.component-inherited-content-area:last-of-type h5 {
+  color: #ffffff;
+  font-size: 0.82rem;
+  margin: 0 0 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 700;
+}
+body > div.component-inherited-content-area:last-of-type a {
+  color: rgba(255, 255, 255, 0.72);
+}
+body > div.component-inherited-content-area:last-of-type a:hover {
+  color: #ffffff;
+}
+body > div.component-inherited-content-area:last-of-type ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+body > div.component-inherited-content-area:last-of-type li {
+  padding: 0.25rem 0;
+  font-size: 0.88rem;
+}
+body > div.component-inherited-content-area:last-of-type .component-richtext > div > div {
+  display: grid !important;
+  grid-template-columns: 2fr 1fr 1fr 1fr;
+  gap: 2rem;
+  max-width: 1080px;
+  margin: 0 auto;
+}
+body > div.component-inherited-content-area:last-of-type .component-richtext > div > div > div {
+  max-width: none !important;
+  flex: none !important;
+}
+body > div.component-inherited-content-area:last-of-type hr {
+  border: none;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  margin: 2rem 0 1rem;
+  max-width: 1080px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* ─── Past-editions table ─────────────────────────────────────────────── */
+body .past-editions-table {
+  width: 100%;
+  max-width: 860px;
+  margin: 1rem auto;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+body .past-editions-table td,
+body .past-editions-table th {
+  padding: 0.85rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid #e8eaf0;
+}
+body .past-editions-table th {
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 0.76rem;
+  letter-spacing: 0.08em;
+  color: #5c6376;
+}
+body .past-editions-table strong { color: #0b0d14; }
+
+/* ─── Small utilities the pages use ───────────────────────────────────── */
+body .signal-center { text-align: center; }
+body .signal-muted { color: #5c6376; }
+body .signal-strong { font-weight: 700; color: #0b0d14; }
+
+
+/* ─── signal-framework 0.0.2 customizations ──────────────────────────
+ * Editorial indigo + red palette, serif display headlines, aurora hero. */
+:root {
+  --signal-primary:     #ff6a4a;
+  --signal-primary-dark:#c23b1d;
+  --signal-ink:         #070814;
+  --signal-indigo:      #1c1f46;
+  --signal-indigo-2:    #2a2e68;
+  --signal-cream:       #f8f5ee;
+}
+body { background: #ffffff; color: #1c1f2a; }
+body > div.component-inherited-content-area:first-of-type { background: var(--signal-ink); }
+body > div.component-inherited-content-area:first-of-type::before { color: var(--signal-primary); }
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) {
+  background: var(--signal-ink) !important;
+  padding: 9rem 2rem 8rem;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area)::before {
+  background:
+    radial-gradient(ellipse 60% 40% at 20% 30%, rgba(255, 106, 74, 0.28) 0%, transparent 60%),
+    radial-gradient(ellipse 50% 60% at 78% 68%, rgba(84, 70, 220, 0.32) 0%, transparent 55%),
+    radial-gradient(ellipse 70% 40% at 50% 100%, rgba(255, 182, 72, 0.14) 0%, transparent 60%),
+    linear-gradient(180deg, var(--signal-ink) 0%, var(--signal-indigo) 100%);
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) h1 {
+  font-family: 'Georgia', 'Libre Caslon Text', 'Baskerville', serif;
+  font-weight: 700;
+  font-size: 4.5rem;
+  letter-spacing: -0.025em;
+  line-height: 0.98;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) .component-text:first-child p {
+  color: var(--signal-primary);
+  font-family: -apple-system, 'Inter', sans-serif;
+  font-weight: 700;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) h2 {
+  font-family: 'Georgia', serif;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) .component-text:first-child p {
+  color: var(--signal-primary);
+}
+body a.ui.button,
+body .component-button-group a {
+  background: linear-gradient(135deg, var(--signal-primary) 0%, var(--signal-primary-dark) 100%);
+  box-shadow: 0 6px 18px rgba(255, 106, 74, 0.3);
+}
+body a.ui.button:hover,
+body .component-button-group a:hover {
+  background: linear-gradient(135deg, var(--signal-primary-dark) 0%, #8c220c 100%);
+}
+body > div:nth-child(4):not(.component-inherited-content-area),
+body > div:nth-child(6):not(.component-inherited-content-area),
+body > div:nth-child(8):not(.component-inherited-content-area),
+body > div:nth-child(10):not(.component-inherited-content-area),
+body > div:nth-child(12):not(.component-inherited-content-area),
+body > div:nth-child(14):not(.component-inherited-content-area) {
+  background: var(--signal-cream);
+}
+body .signal-card-eyebrow { color: var(--signal-primary); }
+body .signal-avatar { background: linear-gradient(135deg, var(--signal-primary), var(--signal-primary-dark)); }
+body a { color: var(--signal-primary); }
+body a:hover { color: var(--signal-primary-dark); }
+body table.schedule-table thead th { background: var(--signal-indigo); }
+body > div.component-inherited-content-area:last-of-type {
+  background: var(--signal-ink);
+  border-top: 3px solid var(--signal-primary);
+}
+
+/* ─── 0.0.3 · bugfix: session card height inconsistency ───────────────
+ * The sessions index had 15 cards with varying abstract length. Some
+ * cards were 180px tall, others 280px, breaking the grid rhythm.
+ * Flex-columns + min-height fix this cleanly and push the level tag
+ * + end-time to the bottom of every card. */
+body .signal-card {
+  display: flex;
+  flex-direction: column;
+  min-height: 220px;
+}
+body .signal-card .signal-card-body { flex: 1 1 auto; }
+body .signal-card .signal-card-foot { margin-top: auto; }
+
+/* ─── 0.0.4 · nav hover underline + card elevation ────────────────────
+ * bugfix: nav items had no hover affordance on dark nav.
+ * improvement: cards were flat — add a subtle lift on hover. */
+body > div.component-inherited-content-area:first-of-type a {
+  position: relative;
+  padding-bottom: 0.15rem;
+}
+body > div.component-inherited-content-area:first-of-type a::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -2px;
+  height: 2px;
+  background: var(--signal-primary);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.2s ease;
+}
+body > div.component-inherited-content-area:first-of-type a:hover::after {
+  transform: scaleX(1);
+}
+body .signal-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 18px 36px rgba(7, 8, 20, 0.10);
+  border-color: rgba(255, 106, 74, 0.35);
+}
+
+/* ─── 0.1.0 · schedule legend + border accents ────────────────────────
+ * Minor release. Adds a small legend row above each day's schedule
+ * table explaining the level tags. Also introduces a left-accent
+ * border on hovered schedule rows in brand red. */
+body .schedule-day {
+  position: relative;
+}
+body .schedule-day h3 + table.schedule-table {
+  margin-top: 1.25rem;
+}
+body .schedule-day h3::after {
+  content: 'Intro · Intermediate · Advanced · levels are a rough guide';
+  display: block;
+  font-size: 0.72rem;
+  font-weight: 500;
+  font-family: 'Inter', sans-serif;
+  color: var(--signal-indigo-2);
+  letter-spacing: 0.05em;
+  margin-top: 0.35rem;
+  text-transform: none;
+}
+body table.schedule-table tbody tr {
+  position: relative;
+  transition: background 0.15s ease, box-shadow 0.15s ease;
+}
+body table.schedule-table tbody tr:hover {
+  background: rgba(255, 106, 74, 0.05);
+  box-shadow: inset 3px 0 0 0 var(--signal-primary);
+}
+
+/* Speaker card avatar bounce on card hover */
+body .signal-card:hover .signal-avatar {
+  transform: scale(1.06) rotate(-3deg);
+  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+body .signal-avatar { transition: transform 0.25s ease; }
+
+/* ─── 1.0.0 · typography ramp, tokens, unified spacing ────────────────
+ * Major release. Introduces a full token system + refined modular
+ * type scale. Visible effect: tighter hero, more breathing room in
+ * cards, and a cleaner footer. */
+:root {
+  --signal-font-display: 'Georgia', 'Libre Caslon Text', 'Baskerville', serif;
+  --signal-font-body:    'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --signal-text:         #1c1f2a;
+  --signal-text-soft:    #5c6376;
+  --signal-border:       #e8e9f0;
+  --signal-radius:       16px;
+  --signal-radius-lg:    22px;
+  --signal-space-1: 0.5rem;
+  --signal-space-2: 1rem;
+  --signal-space-3: 1.5rem;
+  --signal-space-4: 2.25rem;
+  --signal-space-5: 3.5rem;
+  --signal-space-6: 5.5rem;
+  --signal-space-7: 8rem;
+  --signal-step-1: 0.78rem;
+  --signal-step-2: 0.92rem;
+  --signal-step-3: 1.08rem;
+  --signal-step-4: 1.32rem;
+  --signal-step-5: 1.85rem;
+  --signal-step-6: 2.6rem;
+  --signal-step-7: 3.9rem;
+  --signal-step-8: 5.2rem;
+}
+
+body {
+  font-family: var(--signal-font-body);
+  font-size: var(--signal-step-3);
+  color: var(--signal-text);
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) {
+  padding: var(--signal-space-7) var(--signal-space-4) calc(var(--signal-space-7) - 1rem);
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) h1 {
+  font-size: var(--signal-step-8);
+  max-width: 14ch;
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) {
+  padding: var(--signal-space-6) var(--signal-space-4);
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) h2 {
+  font-size: var(--signal-step-7);
+  letter-spacing: -0.02em;
+}
+
+body .signal-card {
+  padding: var(--signal-space-3);
+  border-radius: var(--signal-radius);
+  border-color: var(--signal-border);
+  gap: 0.5rem;
+}
+body .signal-card h3 {
+  font-family: var(--signal-font-display);
+  font-size: var(--signal-step-4);
+  font-weight: 700;
+  letter-spacing: -0.005em;
+}
+
+body .signal-avatar {
+  width: 52px;
+  height: 52px;
+  font-size: var(--signal-step-3);
+}
+
+body .signal-stat .signal-stat-value {
+  font-family: var(--signal-font-display);
+  font-size: var(--signal-step-6);
+}
+body .signal-stat-grid { gap: var(--signal-space-2); }
+
+body table.schedule-table {
+  border-radius: var(--signal-radius);
+  font-size: var(--signal-step-2);
+}
+body table.schedule-table thead th {
+  padding: var(--signal-space-2) var(--signal-space-3);
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+}
+body table.schedule-table td {
+  padding: var(--signal-space-2) var(--signal-space-3);
+}
+
+/* Footer: more breathing room + softer separator */
+body > div.component-inherited-content-area:last-of-type {
+  padding: var(--signal-space-6) var(--signal-space-4) var(--signal-space-4);
+}
+body > div.component-inherited-content-area:last-of-type h4,
+body > div.component-inherited-content-area:last-of-type h5 {
+  font-family: var(--signal-font-body);
+  letter-spacing: 0.14em;
+}
+
+/* ─── 1.1.0 · sticky day jumps + polish ───────────────────────────────
+ * Adds a sticky day-jump row to the schedule page, and new styles
+ * for the sponsor monogram cards, the speaker/session filter bar,
+ * and a couple of speaker-card refinements for the new 12-card grid.
+ */
+
+/* Schedule day-jump — wrap schedule-day h3s in a sticky strip */
+body .schedule-day {
+  scroll-margin-top: 5rem;
+}
+body .schedule-day h3 {
+  position: sticky;
+  top: 4.25rem;
+  background: rgba(255, 255, 255, 0.94);
+  backdrop-filter: blur(6px);
+  padding: 1rem 0 0.75rem;
+  z-index: 10;
+  border-bottom: 1px solid #e8e9f0;
+}
+
+/* Sponsor monogram cards */
+body .sponsor {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 1.4rem 1.6rem 1.25rem;
+  background: #ffffff;
+  border: 1px solid #e2e4ec;
+  border-radius: 16px;
+  min-width: 180px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+body .sponsor:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 18px 36px rgba(28, 31, 70, 0.08);
+}
+body .sponsor .sponsor-logo-svg {
+  width: 72px;
+  height: 72px;
+  display: block;
+}
+body .sponsor .sponsor-logo-svg svg { width: 100%; height: 100%; }
+body .sponsor .sponsor-name {
+  font-weight: 800;
+  color: var(--signal-text, #1c1f2a);
+  font-size: 0.98rem;
+  text-align: center;
+}
+body .sponsor .sponsor-tagline {
+  color: #5c6376;
+  font-size: 0.78rem;
+  text-align: center;
+  max-width: 15ch;
+}
+body .sponsor.tier-gold .sponsor-logo-svg { width: 88px; height: 88px; }
+body .sponsor.tier-silver .sponsor-logo-svg { width: 68px; height: 68px; }
+body .sponsor.tier-bronze .sponsor-logo-svg { width: 56px; height: 56px; }
+body .sponsor.tier-gold { min-width: 220px; padding: 1.75rem 2rem; }
+body .sponsor.tier-bronze { min-width: 150px; padding: 1.1rem 1.2rem; }
+
+/* Filter button row polish */
+body .signal-filter button[data-signal-filter],
+body .signal-filter button[data-signal-filter-level] {
+  font-family: 'Inter', sans-serif;
+  transition: background 0.15s ease, color 0.15s ease, transform 0.1s ease;
+}
+body .signal-filter button[data-signal-filter]:hover,
+body .signal-filter button[data-signal-filter-level]:hover {
+  transform: translateY(-1px);
+}
+
+/* Venue map svg scale */
+body .signal-venue .signal-venue-map svg.venue-map-svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+body .signal-venue .signal-venue-map {
+  padding: 0;
+  background: transparent;
+}
+body .signal-venue .signal-venue-map::before { display: none; }
+body .signal-venue .signal-venue-map .signal-venue-pin { display: none; }
+
+/* Speaker-card grid — tighter column sizing now that there are 12 */
+body .component-richtext > div > div > div:not([class*="uk-grid"]):not([class*="uk-child-width"]):not([class*="uk-flex"]):not(.sponsors-tier):not(.schedule-day):not(.signal-venue):not(.signal-stat-grid) {
+  flex: 1 1 260px;
+  max-width: 320px;
+}
+
+/* ─── 2.0.0 · responsive + dark mode ──────────────────────────────────
+ * Major version. Full responsive pass + a CSS-variable-driven
+ * dark-mode variant that activates on \`prefers-color-scheme: dark\`
+ * AND \`[data-theme="dark"]\` on the html element. Major version
+ * because the token shape changed (tokens now reference semantic
+ * roles like --signal-bg / --signal-fg rather than concrete colours).
+ */
+
+:root {
+  --signal-bg:        #ffffff;
+  --signal-bg-alt:    #f8f5ee;
+  --signal-fg:        #1c1f2a;
+  --signal-fg-soft:   #5c6376;
+  --signal-border:    #e8e9f0;
+  --signal-surface:   #ffffff;
+  --signal-surface-elev: #ffffff;
+  --signal-hero-bg:   #070814;
+  --signal-accent:    #ff6a4a;
+  --signal-accent-2:  #c23b1d;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --signal-bg:        #0a0b14;
+    --signal-bg-alt:    #11121e;
+    --signal-fg:        #e8ebf2;
+    --signal-fg-soft:   #99a1b2;
+    --signal-border:    #252838;
+    --signal-surface:   #14152280;
+    --signal-surface-elev: #1a1c2b;
+    --signal-hero-bg:   #050610;
+  }
+}
+
+html[data-theme="dark"] {
+  --signal-bg:        #0a0b14;
+  --signal-bg-alt:    #11121e;
+  --signal-fg:        #e8ebf2;
+  --signal-fg-soft:   #99a1b2;
+  --signal-border:    #252838;
+  --signal-surface:   #14152280;
+  --signal-surface-elev: #1a1c2b;
+  --signal-hero-bg:   #050610;
+}
+
+body { background: var(--signal-bg); color: var(--signal-fg); }
+body > div:nth-child(4):not(.component-inherited-content-area),
+body > div:nth-child(6):not(.component-inherited-content-area),
+body > div:nth-child(8):not(.component-inherited-content-area),
+body > div:nth-child(10):not(.component-inherited-content-area),
+body > div:nth-child(12):not(.component-inherited-content-area),
+body > div:nth-child(14):not(.component-inherited-content-area) {
+  background: var(--signal-bg-alt);
+}
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) {
+  background: var(--signal-hero-bg) !important;
+}
+
+body .signal-card,
+body .uk-card.uk-card-default,
+body .signal-stat,
+body .sponsor,
+body table.schedule-table {
+  background: var(--signal-surface-elev);
+  border-color: var(--signal-border);
+  color: var(--signal-fg);
+}
+body .signal-card h3 { color: var(--signal-fg); }
+body .signal-card .signal-card-sub { color: var(--signal-fg-soft); }
+body .signal-card .signal-card-body { color: var(--signal-fg); opacity: 0.82; }
+body .signal-stat .signal-stat-value { color: var(--signal-fg); }
+body .signal-stat .signal-stat-label,
+body .sponsor .sponsor-tagline { color: var(--signal-fg-soft); }
+
+body table.schedule-table tr:nth-child(even) td {
+  background: var(--signal-bg-alt);
+}
+body table.schedule-table td { border-color: var(--signal-border); color: var(--signal-fg); }
+body .past-editions-table td,
+body .past-editions-table th { border-color: var(--signal-border); color: var(--signal-fg); }
+body .past-editions-table th { color: var(--signal-fg-soft); }
+body .past-editions-table strong { color: var(--signal-fg); }
+
+body .schedule-day h3 {
+  background: color-mix(in srgb, var(--signal-bg) 90%, transparent);
+  border-color: var(--signal-border);
+  color: var(--signal-fg);
+}
+
+body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) h2 {
+  color: var(--signal-fg);
+}
+
+/* ─── Responsive pass ─────────────────────────────────────────────────
+ * Three breakpoints: 900px (tablet), 640px (phone), 420px (tight). */
+
+@media (max-width: 900px) {
+  body > div.component-inherited-content-area + div:not(.component-inherited-content-area) {
+    padding: 5rem 1.5rem 4.5rem;
+  }
+  body > div.component-inherited-content-area + div:not(.component-inherited-content-area) h1 {
+    font-size: 3rem;
+    line-height: 1.02;
+  }
+  body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) {
+    padding: 3rem 1.5rem;
+  }
+  body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) h2 {
+    font-size: 1.85rem;
+  }
+  body .signal-venue {
+    grid-template-columns: 1fr;
+  }
+  body .signal-venue .signal-venue-map { min-height: 220px; }
+  body > div.component-inherited-content-area:last-of-type .component-richtext > div > div {
+    grid-template-columns: 1fr 1fr !important;
+  }
+  body table.schedule-table {
+    font-size: 0.82rem;
+  }
+  body table.schedule-table td.schedule-title .schedule-speaker {
+    font-size: 0.72rem;
+  }
+}
+
+@media (max-width: 640px) {
+  body > div.component-inherited-content-area:first-of-type {
+    padding: 0.9rem 1.25rem;
+  }
+  body > div.component-inherited-content-area:first-of-type::before {
+    left: 1.25rem;
+    font-size: 0.88rem;
+  }
+  body > div.component-inherited-content-area:first-of-type a {
+    margin-left: 0.85rem;
+    font-size: 0.7rem;
+  }
+  body > div.component-inherited-content-area + div:not(.component-inherited-content-area) {
+    padding: 4rem 1rem 3.5rem;
+  }
+  body > div.component-inherited-content-area + div:not(.component-inherited-content-area) h1 {
+    font-size: 2.35rem;
+  }
+  body > div.component-inherited-content-area + div:not(.component-inherited-content-area) p {
+    font-size: 1rem;
+  }
+  body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) {
+    padding: 2.5rem 1rem;
+  }
+  body > div.component-inherited-content-area + div:not(.component-inherited-content-area) ~ div:not(.component-inherited-content-area) h2 {
+    font-size: 1.5rem;
+  }
+  body .signal-stat-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+  body .signal-stat .signal-stat-value { font-size: 1.65rem; }
+  body .component-richtext > div > div {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1rem;
+  }
+  body .component-richtext > div > div > div:not([class*="uk-grid"]):not([class*="uk-child-width"]):not([class*="uk-flex"]):not(.sponsors-tier):not(.schedule-day):not(.signal-venue):not(.signal-stat-grid) {
+    max-width: none;
+  }
+  body .sponsor-logos {
+    justify-content: center;
+    gap: 1rem;
+  }
+  body .sponsor {
+    min-width: 140px;
+    padding: 1rem;
+  }
+  body .sponsor.tier-gold { min-width: 160px; }
+  body table.schedule-table {
+    min-width: 480px;
+  }
+  body .schedule-day {
+    overflow-x: auto;
+  }
+  body > div.component-inherited-content-area:last-of-type .component-richtext > div > div {
+    grid-template-columns: 1fr !important;
+    gap: 1.5rem;
+  }
+}
+
+@media (max-width: 420px) {
+  body > div.component-inherited-content-area + div:not(.component-inherited-content-area) h1 {
+    font-size: 1.9rem;
+  }
+  body > div.component-inherited-content-area:first-of-type {
+    flex-wrap: wrap;
+  }
+}


### PR DESCRIPTION
New sample UI framework (`signal-framework`) for tech-conference theming on the ui-kit vendor library. Ships eight versions from a baseline theme through a 1.2.0 dark-mode + responsive variant — demonstrates the framework-evolution story the signal-conf sample site uses on QA. Parallel to #44 (league-framework) — same shape, different content.