### PR TITLE
Fix ui-kit table-cell view to render tableCell.text

### DIFF
--- a/vendor-libraries/ui-kit/src/content/jcr_root/apps/kestros/commons/components/content/table-cell/ui-kit-lib/3.23.6/layouts/default/content.html
+++ b/vendor-libraries/ui-kit/src/content/jcr_root/apps/kestros/commons/components/content/table-cell/ui-kit-lib/3.23.6/layouts/default/content.html
@@ -2,5 +2,6 @@
 <sly data-sly-use.includes="/libs/kestros/commons/components/includes.html"/>
 
 <td class="${tableCell.inlineVariations}">
+    <sly data-sly-test="${tableCell.text}">${tableCell.text}</sly>
     <sly data-sly-call="${includes.contentArea}"/>
 </td>


### PR DESCRIPTION
## Summary
Adds `<sly data-sly-test="${tableCell.text}">${tableCell.text}</sly>` to the ui-kit table-cell layout content.html. Without this, synthetic table cells from datasources render empty `<td>` elements.

Companion to kestros/kestros-basic-components fix/synthetic-table-rendering.

## Test plan
- [x] League-demo game-log table cells render text on QA