### PR TITLE
fix: vendor lib reference consistency and missing framework codes

### DIFF
--- a/ui-frameworks/express-framework/src/content/jcr_root/etc/ui-frameworks/express/versions/0.0.1/.content.xml
+++ b/ui-frameworks/express-framework/src/content/jcr_root/etc/ui-frameworks/express/versions/0.0.1/.content.xml
@@ -6,5 +6,5 @@
           jcr:title="Express 0.0.1"
           jcr:description="Generic usage of the Bootstrap framework, with FontAwesome providing icons."
           kes:uiFrameworkCode="express"
-          kes:vendorLibraries="[bootstrap/5.3.8,font-awesome/5.11.2]"
+          kes:vendorLibraries="[bootstrap/1.0.0,font-awesome/1.0.0]"
           fontAwesomeIcon="fab fa-bootstrap"/>

--- a/ui-frameworks/kestros-io-site-framework/src/content/jcr_root/etc/ui-frameworks/kestros-io-site/.content.xml
+++ b/ui-frameworks/kestros-io-site-framework/src/content/jcr_root/etc/ui-frameworks/kestros-io-site/.content.xml
@@ -4,4 +4,5 @@
           xmlns:kes="http://kestros.io/kes/1.0"
           jcr:primaryType="kes:ManagedUiFramework"
           jcr:title="Kestros IO Site"
+          kes:uiFrameworkCode="kestros-io-site"
 />

--- a/ui-frameworks/league-framework-v2/content/src/content/jcr_root/etc/ui-frameworks/league-framework-v2/.content.xml
+++ b/ui-frameworks/league-framework-v2/content/src/content/jcr_root/etc/ui-frameworks/league-framework-v2/.content.xml
@@ -4,4 +4,5 @@
           jcr:primaryType="kes:ManagedUiFramework"
           jcr:title="League Framework v2"
           jcr:description="Bootstrap 5 based league framework with full component coverage."
+          kes:uiFrameworkCode="league-framework-v2"
 />

--- a/ui-frameworks/league-framework-v2/content/src/content/jcr_root/etc/ui-frameworks/league-framework-v2/versions/0.0.1/.content.xml
+++ b/ui-frameworks/league-framework-v2/content/src/content/jcr_root/etc/ui-frameworks/league-framework-v2/versions/0.0.1/.content.xml
@@ -5,5 +5,5 @@
           jcr:title="League Framework v2 0.0.1"
           jcr:description="Bootstrap 5 base. Dark navbar, league branding, card and table styling."
           kes:uiFrameworkCode="league-framework-v2"
-          kes:vendorLibraries="[bootstrap/5.3.8]"
+          kes:vendorLibraries="[bootstrap/1.0.0]"
 />

--- a/ui-frameworks/league-framework/content/src/content/jcr_root/etc/ui-frameworks/league-framework/.content.xml
+++ b/ui-frameworks/league-framework/content/src/content/jcr_root/etc/ui-frameworks/league-framework/.content.xml
@@ -3,4 +3,5 @@
           jcr:primaryType="kes:ManagedUiFramework"
           jcr:title="League Framework"
           jcr:description="Sport-league sample framework on the ui-kit vendor library. Demonstrates framework evolution across six versions from baseline theming through a major token refactor."
+          kes:uiFrameworkCode="league-framework"
 />

--- a/ui-frameworks/league-framework/content/src/content/jcr_root/etc/ui-frameworks/league-framework/versions/0.0.1/.content.xml
+++ b/ui-frameworks/league-framework/content/src/content/jcr_root/etc/ui-frameworks/league-framework/versions/0.0.1/.content.xml
@@ -5,5 +5,5 @@
           jcr:title="League Framework 0.0.1"
           jcr:description="Baseline — generic sport-league theming on top of ui-kit."
           kes:uiFrameworkCode="league-framework"
-          kes:vendorLibraries="[ui-kit/3.23.6]"
+          kes:vendorLibraries="[ui-kit/1.0.0]"
 />

--- a/ui-frameworks/league-framework/content/src/content/jcr_root/etc/ui-frameworks/league-framework/versions/0.0.2/.content.xml
+++ b/ui-frameworks/league-framework/content/src/content/jcr_root/etc/ui-frameworks/league-framework/versions/0.0.2/.content.xml
@@ -5,5 +5,5 @@
           jcr:title="League Framework 0.0.2"
           jcr:description="Brand pass — pitch-green palette, field-stripe hero gradient, gold accent buttons."
           kes:uiFrameworkCode="league-framework"
-          kes:vendorLibraries="[ui-kit/3.23.6]"
+          kes:vendorLibraries="[ui-kit/1.0.0]"
 />

--- a/ui-frameworks/league-framework/content/src/content/jcr_root/etc/ui-frameworks/league-framework/versions/0.0.3/.content.xml
+++ b/ui-frameworks/league-framework/content/src/content/jcr_root/etc/ui-frameworks/league-framework/versions/0.0.3/.content.xml
@@ -5,5 +5,5 @@
           jcr:title="League Framework 0.0.3"
           jcr:description="Bugfix — standings table horizontal overflow on narrow viewports."
           kes:uiFrameworkCode="league-framework"
-          kes:vendorLibraries="[ui-kit/3.23.6]"
+          kes:vendorLibraries="[ui-kit/1.0.0]"
 />

--- a/ui-frameworks/league-framework/content/src/content/jcr_root/etc/ui-frameworks/league-framework/versions/0.0.4/.content.xml
+++ b/ui-frameworks/league-framework/content/src/content/jcr_root/etc/ui-frameworks/league-framework/versions/0.0.4/.content.xml
@@ -5,5 +5,5 @@
           jcr:title="League Framework 0.0.4"
           jcr:description="Bugfix — button focus outlines + consistent team card heights."
           kes:uiFrameworkCode="league-framework"
-          kes:vendorLibraries="[ui-kit/3.23.6]"
+          kes:vendorLibraries="[ui-kit/1.0.0]"
 />

--- a/ui-frameworks/league-framework/content/src/content/jcr_root/etc/ui-frameworks/league-framework/versions/0.1.0/.content.xml
+++ b/ui-frameworks/league-framework/content/src/content/jcr_root/etc/ui-frameworks/league-framework/versions/0.1.0/.content.xml
@@ -5,5 +5,5 @@
           jcr:title="League Framework 0.1.0"
           jcr:description="Minor — stats ticker ribbon under the hero + row-hover on all tables."
           kes:uiFrameworkCode="league-framework"
-          kes:vendorLibraries="[ui-kit/3.23.6]"
+          kes:vendorLibraries="[ui-kit/1.0.0]"
 />

--- a/ui-frameworks/league-framework/content/src/content/jcr_root/etc/ui-frameworks/league-framework/versions/1.0.0/.content.xml
+++ b/ui-frameworks/league-framework/content/src/content/jcr_root/etc/ui-frameworks/league-framework/versions/1.0.0/.content.xml
@@ -5,5 +5,5 @@
           jcr:title="League Framework 1.0.0"
           jcr:description="Major — unified design token system, refined type scale, section rhythm."
           kes:uiFrameworkCode="league-framework"
-          kes:vendorLibraries="[ui-kit/3.23.6]"
+          kes:vendorLibraries="[ui-kit/1.0.0]"
 />

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/.content.xml
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/.content.xml
@@ -3,4 +3,5 @@
           jcr:primaryType="kes:ManagedUiFramework"
           jcr:title="Signal Framework"
           jcr:description="Tech-conference sample framework on the ui-kit vendor library. Demonstrates framework evolution across eight versions from baseline theming through responsive + dark-mode support."
+          kes:uiFrameworkCode="signal-framework"
 />

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.1/.content.xml
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.1/.content.xml
@@ -5,5 +5,5 @@
           jcr:title="Signal Framework 0.0.1"
           jcr:description="Baseline — generic tech-conference theming on top of ui-kit."
           kes:uiFrameworkCode="signal-framework"
-          kes:vendorLibraries="[ui-kit/3.23.6]"
+          kes:vendorLibraries="[ui-kit/1.0.0]"
 />

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.2/.content.xml
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.2/.content.xml
@@ -5,5 +5,5 @@
           jcr:title="Signal Framework 0.0.2"
           jcr:description="Brand pass — editorial red/indigo palette with an aurora hero treatment."
           kes:uiFrameworkCode="signal-framework"
-          kes:vendorLibraries="[ui-kit/3.23.6]"
+          kes:vendorLibraries="[ui-kit/1.0.0]"
 />

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.3/.content.xml
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.3/.content.xml
@@ -5,5 +5,5 @@
           jcr:title="Signal Framework 0.0.3"
           jcr:description="Card elevation — session and speaker card shadows + border treatment."
           kes:uiFrameworkCode="signal-framework"
-          kes:vendorLibraries="[ui-kit/3.23.6]"
+          kes:vendorLibraries="[ui-kit/1.0.0]"
 />

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.4/.content.xml
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.0.4/.content.xml
@@ -5,5 +5,5 @@
           jcr:title="Signal Framework 0.0.4"
           jcr:description="Schedule table — agenda time-slot alignment + session row styling."
           kes:uiFrameworkCode="signal-framework"
-          kes:vendorLibraries="[ui-kit/3.23.6]"
+          kes:vendorLibraries="[ui-kit/1.0.0]"
 />

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.1.0/.content.xml
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/0.1.0/.content.xml
@@ -5,5 +5,5 @@
           jcr:title="Signal Framework 0.1.0"
           jcr:description="Minor — venue page layout + sponsor grid treatment."
           kes:uiFrameworkCode="signal-framework"
-          kes:vendorLibraries="[ui-kit/3.23.6]"
+          kes:vendorLibraries="[ui-kit/1.0.0]"
 />

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/1.0.0/.content.xml
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/1.0.0/.content.xml
@@ -5,5 +5,5 @@
           jcr:title="Signal Framework 1.0.0"
           jcr:description="Major — interactive schedule filters + speaker bio expand/collapse styling."
           kes:uiFrameworkCode="signal-framework"
-          kes:vendorLibraries="[ui-kit/3.23.6]"
+          kes:vendorLibraries="[ui-kit/1.0.0]"
 />

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/1.1.0/.content.xml
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/1.1.0/.content.xml
@@ -5,5 +5,5 @@
           jcr:title="Signal Framework 1.1.0"
           jcr:description="Live stream + video archive — video embed treatment and archive list."
           kes:uiFrameworkCode="signal-framework"
-          kes:vendorLibraries="[ui-kit/3.23.6]"
+          kes:vendorLibraries="[ui-kit/1.0.0]"
 />

--- a/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/1.2.0/.content.xml
+++ b/ui-frameworks/signal-framework/src/content/jcr_root/etc/ui-frameworks/signal-framework/versions/1.2.0/.content.xml
@@ -5,5 +5,5 @@
           jcr:title="Signal Framework 1.2.0"
           jcr:description="Dark mode + responsive — full dark-theme variant with system-preference detection."
           kes:uiFrameworkCode="signal-framework"
-          kes:vendorLibraries="[ui-kit/3.23.6]"
+          kes:vendorLibraries="[ui-kit/1.0.0]"
 />

--- a/ui-frameworks/tachyons-framework/src/content/jcr_root/etc/ui-frameworks/tachyons/.content.xml
+++ b/ui-frameworks/tachyons-framework/src/content/jcr_root/etc/ui-frameworks/tachyons/.content.xml
@@ -2,4 +2,5 @@
           xmlns:kes="http://kestros.io/kes/1.0"
           jcr:primaryType="kes:ManagedUiFramework"
           jcr:title="Tachyons Ui Framework"
+          kes:uiFrameworkCode="tachyons"
 />

--- a/ui-frameworks/tailwind-framework/src/content/jcr_root/etc/ui-frameworks/tailwind-framework/.content.xml
+++ b/ui-frameworks/tailwind-framework/src/content/jcr_root/etc/ui-frameworks/tailwind-framework/.content.xml
@@ -2,4 +2,5 @@
           xmlns:kes="http://kestros.io/kes/1.0"
           jcr:primaryType="kes:ManagedUiFramework"
           jcr:title="Tailwind Ui Framework"
+          kes:uiFrameworkCode="tailwind"
 />

--- a/vendor-libraries/nova-parallax/src/content/jcr_root/etc/vendor-libraries/nova-parallax/.content.xml
+++ b/vendor-libraries/nova-parallax/src/content/jcr_root/etc/vendor-libraries/nova-parallax/.content.xml
@@ -5,4 +5,5 @@
           jcr:title="Nova Parallax"
           jcr:description="Accessibility-aware scroll-driven parallax library. IntersectionObserver-gated, respects prefers-reduced-motion, opts out on touch + narrow viewports."
           fontAwesomeIcon="fab fa-js"
+          kes:libraryCode="nova-parallax-lib"
 />

--- a/vendor-libraries/rellax/src/content/jcr_root/etc/vendor-libraries/rellax/.content.xml
+++ b/vendor-libraries/rellax/src/content/jcr_root/etc/vendor-libraries/rellax/.content.xml
@@ -6,4 +6,5 @@
           jcr:description="Vanilla javascript parallax library."
           fontAwesomeIcon="fab fa-js"
           documentationUrl="https://github.com/dixonandmoe/rellax"
+          kes:libraryCode="rellax-lib"
 />


### PR DESCRIPTION
## Summary
- Update all framework vendor library references from old version paths (3.23.6, 5.3.8, 5.11.2) to the current 1.0.0 versioning
- Add missing `kes:uiFrameworkCode` to 6 frameworks
- Add missing `kes:libraryCode` to 2 vendor libraries

## Frameworks fixed
| Framework | Change |
|---|---|
| league-framework (all 6 versions) | `ui-kit/3.23.6` -> `ui-kit/1.0.0`, add `kes:uiFrameworkCode` |
| league-framework-v2 | `bootstrap/5.3.8` -> `bootstrap/1.0.0`, add `kes:uiFrameworkCode` |
| signal-framework (all 8 versions) | `ui-kit/3.23.6` -> `ui-kit/1.0.0`, add `kes:uiFrameworkCode` |
| express-framework | `bootstrap/5.3.8` -> `bootstrap/1.0.0`, `font-awesome/5.11.2` -> `font-awesome/1.0.0` |
| tachyons-framework | add `kes:uiFrameworkCode` |
| tailwind-framework | add `kes:uiFrameworkCode` |
| kestros-io-site-framework | add `kes:uiFrameworkCode` |

## Vendor libraries fixed
| Library | Change |
|---|---|
| nova-parallax | add `kes:libraryCode` |
| rellax | add `kes:libraryCode` |

## Not addressed (separate work)
- Legacy vendor libs (font-awesome, jquery, leafletjs, minigrid, popper) use JSON config format instead of .content.xml
- bootstrap-framework module duplicates express-framework (same code, same JCR path)