### PR TITLE
fix: framework descriptions, ui-kit code, bootstrap identity

### DIFF
--- a/ui-frameworks/bootstrap-framework/src/content/jcr_root/etc/ui-frameworks/express/.content.xml
+++ b/ui-frameworks/bootstrap-framework/src/content/jcr_root/etc/ui-frameworks/express/.content.xml
@@ -3,7 +3,7 @@
           xmlns:jcr="http://www.jcp.org/jcr/1.0"
           xmlns:kes="http://kestros.io/kes/1.0"
           jcr:primaryType="kes:ManagedUiFramework"
-          jcr:title="Express"
-          jcr:description="Generic usage of the Bootstrap framework, with FontAwesome providing icons."
-          kes:uiFrameworkCode="express"
+          jcr:title="Bootstrap"
+          jcr:description="The most popular HTML, CSS, and JavaScript framework for developing responsive, mobile-first websites."
+          kes:uiFrameworkCode="bootstrap"
           fontAwesomeIcon="fab fa-bootstrap"/>

--- a/ui-frameworks/bulma-framework/src/content/jcr_root/etc/ui-frameworks/bloom/.content.xml
+++ b/ui-frameworks/bulma-framework/src/content/jcr_root/etc/ui-frameworks/bloom/.content.xml
@@ -4,5 +4,5 @@
           xmlns:kes="http://kestros.io/kes/1.0"
           jcr:primaryType="kes:ManagedUiFramework"
           jcr:title="Bloom"
-          jcr:description=""
+          jcr:description="Kestros framework built on Bulma, a free and open-source CSS framework based on Flexbox."
           kes:uiFrameworkCode="bloom"/>

--- a/ui-frameworks/kestros-io-site-framework/src/content/jcr_root/etc/ui-frameworks/kestros-io-site/.content.xml
+++ b/ui-frameworks/kestros-io-site-framework/src/content/jcr_root/etc/ui-frameworks/kestros-io-site/.content.xml
@@ -4,5 +4,6 @@
           xmlns:kes="http://kestros.io/kes/1.0"
           jcr:primaryType="kes:ManagedUiFramework"
           jcr:title="Kestros IO Site"
+          jcr:description="Custom framework for the kestros.io website. Built on Bootstrap with FlexStart-inspired view overrides."
           kes:uiFrameworkCode="kestros-io-site"
 />

--- a/ui-frameworks/nova-framework/src/content/jcr_root/etc/ui-frameworks/nova-framework/.content.xml
+++ b/ui-frameworks/nova-framework/src/content/jcr_root/etc/ui-frameworks/nova-framework/.content.xml
@@ -4,5 +4,6 @@
           xmlns:kes="http://kestros.io/kes/1.0"
           jcr:primaryType="kes:ManagedUiFramework"
           jcr:title="Nova Framework"
+          jcr:description="Custom CSS framework with parallax and lazy-loading image layouts. Built on the nova-css vendor library."
           kes:uiFrameworkCode="nova-framework"
 />

--- a/ui-frameworks/tachyons-framework/src/content/jcr_root/etc/ui-frameworks/tachyons/.content.xml
+++ b/ui-frameworks/tachyons-framework/src/content/jcr_root/etc/ui-frameworks/tachyons/.content.xml
@@ -1,6 +1,7 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
           xmlns:kes="http://kestros.io/kes/1.0"
           jcr:primaryType="kes:ManagedUiFramework"
-          jcr:title="Tachyons Ui Framework"
+          jcr:title="Tachyons"
+          jcr:description="Functional CSS framework. Create fast-loading, highly readable, and fully responsive interfaces with as little CSS as possible."
           kes:uiFrameworkCode="tachyons"
 />

--- a/ui-frameworks/tailwind-framework/src/content/jcr_root/etc/ui-frameworks/tailwind-framework/.content.xml
+++ b/ui-frameworks/tailwind-framework/src/content/jcr_root/etc/ui-frameworks/tailwind-framework/.content.xml
@@ -1,6 +1,7 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
           xmlns:kes="http://kestros.io/kes/1.0"
           jcr:primaryType="kes:ManagedUiFramework"
-          jcr:title="Tailwind Ui Framework"
+          jcr:title="Tailwind CSS"
+          jcr:description="A utility-first CSS framework for rapidly building custom user interfaces."
           kes:uiFrameworkCode="tailwind"
 />

--- a/ui-frameworks/ui-kit-framework/src/content/jcr_root/etc/ui-frameworks/ui-kit/.content.xml
+++ b/ui-frameworks/ui-kit-framework/src/content/jcr_root/etc/ui-frameworks/ui-kit/.content.xml
@@ -1,5 +1,7 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
           xmlns:kes="http://kestros.io/kes/1.0"
           jcr:primaryType="kes:ManagedUiFramework"
-          jcr:title="UIkit Ui Framework"
+          jcr:title="UIkit"
+          jcr:description="A lightweight and modular front-end framework for developing fast and powerful web interfaces."
+          kes:uiFrameworkCode="ui-kit"
 />


### PR DESCRIPTION
## Summary
- Add missing `kes:uiFrameworkCode` to ui-kit-framework
- Add `jcr:description` to all frameworks that were missing it
- Rename bootstrap-framework code from `express` to `bootstrap`
- Clean up framework titles

## Changes
| Framework | Change |
|---|---|
| ui-kit-framework | Add `kes:uiFrameworkCode="ui-kit"`, add description, title "UIkit" |
| bootstrap-framework | Code `express` -> `bootstrap`, title "Express" -> "Bootstrap", add description |
| bulma-framework (bloom) | Add description |
| kestros-io-site-framework | Add description |
| nova-framework | Add description |
| tachyons-framework | Add description, title "Tachyons" |
| tailwind-framework | Add description, title "Tailwind CSS" |