### PR TITLE
feat(bootstrap-lib): add responsive 33/33/33 three-column grid layout

### DIFF
--- a/vendor-libraries/bootstrap/src/content/jcr_root/apps/kestros/commons/components/structure/grid/bootstrap-lib/1.0.0/layouts/33-33-33/.content.xml
+++ b/vendor-libraries/bootstrap/src/content/jcr_root/apps/kestros/commons/components/structure/grid/bootstrap-lib/1.0.0/layouts/33-33-33/.content.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:kes="http://kestros.io/kes/1.0"
+          jcr:primaryType="kes:Layout"
+          jcr:title="33/33/33"
+          jcr:description="Three equal columns; stacks on mobile."/>

--- a/vendor-libraries/bootstrap/src/content/jcr_root/apps/kestros/commons/components/structure/grid/bootstrap-lib/1.0.0/layouts/33-33-33/content.html
+++ b/vendor-libraries/bootstrap/src/content/jcr_root/apps/kestros/commons/components/structure/grid/bootstrap-lib/1.0.0/layouts/33-33-33/content.html
@@ -1,0 +1,12 @@
+<sly data-sly-use.grid="${'io.kestros.cms.components.basic.core.structure.grid.GridDataSourceComponent'}"/>
+<div class="row ${grid.inlineVariations}">
+    <div class="col-md-4">
+        <sly data-sly-resource="${'column-1' @ resourceType='kestros/commons/components/content-area'}"/>
+    </div>
+    <div class="col-md-4">
+        <sly data-sly-resource="${'column-2' @ resourceType='kestros/commons/components/content-area'}"/>
+    </div>
+    <div class="col-md-4">
+        <sly data-sly-resource="${'column-3' @ resourceType='kestros/commons/components/content-area'}"/>
+    </div>
+</div>


### PR DESCRIPTION
Board: `bootstrap-lib-grid-layouts` (id bslibgrid). Ruling (Danny 2026-07-15): basic grid configs live in bootstrap-lib as LAYOUTS.

## Finding (corrects the story premise)
The grid component's bootstrap-lib layout set ALREADY exists and is complete for ratios: Default, 50/50, 33/66, 66/33, 25/75, 75/25, 25/25/25/25, plus a gutters variation — each wraps the grid's named `column-N` content-areas in a Bootstrap `row` + `col-*`. The real authoring gap the ACPL demo hit was authors putting raw `row`/`col-md-4` on **containers** (which the style-mode picker can't offer) instead of using the **grid** component.

## Change
The one genuinely missing layout: a responsive **even 3-column (33/33/33)** — `col-md-4` ×3 (thirds on md+, stacked on mobile). Default's three plain `col` columns never stack, so this fills the common "3 columns" case Danny named.

**Verified on :8084** (content package deployed): layouts now = 25-25-25-25, 25-75, **33-33-33**, 33-66, 50-50, 66-33, 75-25, default; the new node is a kes:Layout titled "33/33/33".

Follow-up for the demo (separate): ACPL pass-2 content should use the grid component for column layouts rather than col-* on containers.
